### PR TITLE
Fix turn stalls on non-Anthropic models

### DIFF
--- a/internal/backend/openaibe/backend.go
+++ b/internal/backend/openaibe/backend.go
@@ -69,8 +69,12 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 	if req.Stream {
 		sse := anthropic.NewSSEWriter(w)
 		state := newStreamState(sse, call.Envelope.Model)
-		usage, errType := state.Run(resp.Body)
-		return backend.Result{Status: 200, Usage: usage, ErrType: errType}
+		usage, errType := state.Run(ctx, resp.Body)
+		status := 200
+		if errType == "client_disconnect" {
+			status = 499
+		}
+		return backend.Result{Status: status, Usage: usage, ErrType: errType}
 	}
 
 	raw, err := io.ReadAll(resp.Body)

--- a/internal/backend/openaibe/stream.go
+++ b/internal/backend/openaibe/stream.go
@@ -3,8 +3,10 @@ package openaibe
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
+	"time"
 
 	"github.com/maorbril/agentic/internal/anthropic"
 	"github.com/maorbril/agentic/internal/openai"
@@ -23,65 +25,113 @@ type streamState struct {
 	index        int    // next content block index
 	openType     string // "", "thinking", "text", "tool"
 	openaiToolIx int    // openai tool_call index of the open tool block
+	openToolID   string // openai tool_call id of the open tool block
 	pendingArgs  string // tool args buffered before the block could open
 	pendingID    string
 	pendingName  string
 	havePending  bool
 
-	finishReason string
-	sawToolCall  bool
-	usage        anthropic.Usage
+	finishReason   string
+	sawToolCall    bool
+	usage          anthropic.Usage
+	keepAliveEvery time.Duration // ping cadence while the upstream is quiet
 }
 
 func newStreamState(sse *anthropic.SSEWriter, alias string) *streamState {
-	return &streamState{sse: sse, alias: alias, openaiToolIx: -1}
+	return &streamState{sse: sse, alias: alias, openaiToolIx: -1, keepAliveEvery: 15 * time.Second}
 }
 
-// Run consumes the upstream SSE body until EOF or [DONE], returning final
-// usage. A mid-stream upstream error is forwarded as an Anthropic error
-// event (Claude Code retries on it).
-func (s *streamState) Run(body io.Reader) (anthropic.Usage, string) {
-	scanner := bufio.NewScanner(body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		data, ok := bytes.CutPrefix(line, []byte("data: "))
-		if !ok {
-			continue
+// Run consumes the upstream SSE body until EOF, [DONE], or ctx cancellation,
+// returning final usage. A mid-stream upstream error is forwarded as an
+// Anthropic error event (Claude Code retries on it). While the upstream is
+// quiet — slow reasoning models can sit for a minute before the first token —
+// pings keep the client from timing out on a byte-silent connection.
+func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage, string) {
+	lines := make(chan []byte)
+	scanErr := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+		for scanner.Scan() {
+			line := append([]byte(nil), scanner.Bytes()...)
+			select {
+			case lines <- line:
+			case <-ctx.Done():
+				return
+			}
 		}
-		if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
-			break
+		scanErr <- scanner.Err()
+	}()
+
+	keepAlive := time.NewTicker(s.keepAliveEvery)
+	defer keepAlive.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Client hung up or the turn was cancelled; the transport closes
+			// the upstream body for us, so just stop translating.
+			return s.usage, "client_disconnect"
+		case <-keepAlive.C:
+			s.ping()
+		case err := <-scanErr:
+			if err != nil {
+				s.sse.ErrorEvent("api_error", "upstream stream: "+err.Error())
+				return s.usage, "api_error"
+			}
+			s.finalize()
+			return s.usage, ""
+		case line := <-lines:
+			data, ok := bytes.CutPrefix(line, []byte("data: "))
+			if !ok {
+				continue
+			}
+			if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
+				s.finalize()
+				return s.usage, ""
+			}
+			var chunk openai.Chunk
+			if err := json.Unmarshal(data, &chunk); err != nil {
+				continue // tolerate provider noise between data lines
+			}
+			if chunk.Error != nil {
+				s.sse.ErrorEvent("api_error", "upstream: "+chunk.Error.Message)
+				return s.usage, "api_error"
+			}
+			s.handleChunk(&chunk)
 		}
-		var chunk openai.Chunk
-		if err := json.Unmarshal(data, &chunk); err != nil {
-			continue // tolerate provider noise between data lines
-		}
-		if chunk.Error != nil {
-			s.sse.ErrorEvent("api_error", "upstream: "+chunk.Error.Message)
-			return s.usage, "api_error"
-		}
-		s.handleChunk(&chunk)
 	}
-	if err := scanner.Err(); err != nil {
-		s.sse.ErrorEvent("api_error", "upstream stream: "+err.Error())
-		return s.usage, "api_error"
+}
+
+// ping keeps the client connection alive while the upstream is quiet. The
+// SSE grammar requires message_start first, so if no chunk has arrived yet
+// the message is opened with a synthetic id (handleChunk won't re-open it).
+func (s *streamState) ping() {
+	if !s.started {
+		s.startMessage("msg_agentic_pending")
+		return // startMessage already pings
 	}
-	s.finalize()
-	return s.usage, ""
+	s.sse.Ping()
+}
+
+// startMessage emits message_start + ping once; later calls are no-ops.
+func (s *streamState) startMessage(id string) {
+	if s.started {
+		return
+	}
+	s.started = true
+	s.sse.Event("message_start", map[string]any{
+		"type": "message_start",
+		"message": anthropic.MessagesResponse{
+			ID: id, Type: "message", Role: "assistant",
+			Model: s.alias, Content: []anthropic.ContentBlock{},
+		},
+	})
+	s.sse.Ping()
 }
 
 func (s *streamState) handleChunk(chunk *openai.Chunk) {
-	if !s.started {
-		s.started = true
-		s.sse.Event("message_start", map[string]any{
-			"type": "message_start",
-			"message": anthropic.MessagesResponse{
-				ID: "msg_" + chunk.ID, Type: "message", Role: "assistant",
-				Model: s.alias, Content: []anthropic.ContentBlock{},
-			},
-		})
-		s.sse.Ping()
-	}
+	s.startMessage("msg_" + chunk.ID)
 	if chunk.Usage != nil {
 		s.usage = mapUsage(chunk.Usage)
 	}
@@ -114,14 +164,23 @@ func (s *streamState) handleChunk(chunk *openai.Chunk) {
 }
 
 func (s *streamState) handleToolDelta(tc openai.ToolCall) {
-	ix := 0
+	// A tool call is in progress while its block is open or its header is
+	// still buffering. A new call is signaled by a different openai index,
+	// or — for providers that omit the index — by a fresh id. Fragments with
+	// neither continue the call in progress.
+	inTool := s.openType == "tool" || s.havePending
+	newTool := !inTool
 	if tc.Index != nil {
-		ix = *tc.Index
+		newTool = newTool || *tc.Index != s.openaiToolIx
+	} else if tc.ID != "" && tc.ID != s.currentToolID() {
+		newTool = true
 	}
-	newTool := s.openType != "tool" || ix != s.openaiToolIx
 	if newTool {
 		s.closeBlock()
-		s.openaiToolIx = ix
+		s.openaiToolIx = -1
+		if tc.Index != nil {
+			s.openaiToolIx = *tc.Index
+		}
 		s.pendingID, s.pendingName, s.pendingArgs = tc.ID, tc.Function.Name, ""
 		s.havePending = true
 	} else if s.havePending {
@@ -146,6 +205,15 @@ func (s *streamState) handleToolDelta(tc openai.ToolCall) {
 	}
 }
 
+// currentToolID is the openai id of the call in progress: the buffered
+// header's id before the block opens, the open block's id after.
+func (s *streamState) currentToolID() string {
+	if s.havePending {
+		return s.pendingID
+	}
+	return s.openToolID
+}
+
 func (s *streamState) openToolBlock() {
 	id := s.pendingID
 	if id == "" {
@@ -156,6 +224,7 @@ func (s *streamState) openToolBlock() {
 		"content_block": map[string]any{"type": "tool_use", "id": id, "name": s.pendingName, "input": map[string]any{}},
 	})
 	s.openType = "tool"
+	s.openToolID = s.pendingID
 	s.sawToolCall = true
 	s.index++
 	args := s.pendingArgs
@@ -214,6 +283,7 @@ func (s *streamState) closeBlock() {
 	s.sse.Event("content_block_stop", map[string]any{"type": "content_block_stop", "index": s.index - 1})
 	s.openType = ""
 	s.openaiToolIx = -1
+	s.openToolID = ""
 }
 
 func (s *streamState) finalize() {

--- a/internal/backend/openaibe/stream.go
+++ b/internal/backend/openaibe/stream.go
@@ -22,6 +22,7 @@ type streamState struct {
 	alias string
 
 	started      bool
+	sawChunk     bool   // a real upstream chunk arrived (vs synthetic keep-alive start)
 	index        int    // next content block index
 	openType     string // "", "thinking", "text", "tool"
 	openaiToolIx int    // openai tool_call index of the open tool block
@@ -49,6 +50,8 @@ func newStreamState(sse *anthropic.SSEWriter, alias string) *streamState {
 func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage, string) {
 	lines := make(chan []byte)
 	scanErr := make(chan error, 1)
+	quit := make(chan struct{}) // frees the reader if Run returns before EOF
+	defer close(quit)
 	go func() {
 		scanner := bufio.NewScanner(body)
 		scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
@@ -57,6 +60,8 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 			select {
 			case lines <- line:
 			case <-ctx.Done():
+				return
+			case <-quit:
 				return
 			}
 		}
@@ -79,16 +84,14 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 				s.sse.ErrorEvent("api_error", "upstream stream: "+err.Error())
 				return s.usage, "api_error"
 			}
-			s.finalize()
-			return s.usage, ""
+			return s.usage, s.finalize()
 		case line := <-lines:
 			data, ok := bytes.CutPrefix(line, []byte("data: "))
 			if !ok {
 				continue
 			}
 			if bytes.Equal(bytes.TrimSpace(data), []byte("[DONE]")) {
-				s.finalize()
-				return s.usage, ""
+				return s.usage, s.finalize()
 			}
 			var chunk openai.Chunk
 			if err := json.Unmarshal(data, &chunk); err != nil {
@@ -131,6 +134,7 @@ func (s *streamState) startMessage(id string) {
 }
 
 func (s *streamState) handleChunk(chunk *openai.Chunk) {
+	s.sawChunk = true
 	s.startMessage("msg_" + chunk.ID)
 	if chunk.Usage != nil {
 		s.usage = mapUsage(chunk.Usage)
@@ -286,11 +290,16 @@ func (s *streamState) closeBlock() {
 	s.openToolID = ""
 }
 
-func (s *streamState) finalize() {
-	if !s.started {
-		// Upstream sent nothing usable.
+// finalize closes the stream grammar, returning a non-empty errType if the
+// stream ended without anything usable.
+func (s *streamState) finalize() string {
+	if !s.sawChunk {
+		// Upstream sent nothing usable. Checked against sawChunk, not
+		// started: a keep-alive ping may have opened the message
+		// synthetically, but an empty stream is still an error — Claude
+		// Code retries on the error event, not on an empty message.
 		s.sse.ErrorEvent("api_error", "upstream produced no chunks")
-		return
+		return "api_error"
 	}
 	s.closeBlock()
 	s.sse.Event("message_delta", map[string]any{
@@ -303,4 +312,5 @@ func (s *streamState) finalize() {
 		},
 	})
 	s.sse.Event("message_stop", map[string]any{"type": "message_stop"})
+	return ""
 }

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -1,10 +1,13 @@
 package openaibe
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/maorbril/agentic/internal/anthropic"
 )
@@ -20,7 +23,7 @@ func runStream(t *testing.T, chunks []string) []event {
 		body += "data: " + c + "\n\n"
 	}
 	body += "data: [DONE]\n\n"
-	usage, errType := state.Run(strings.NewReader(body))
+	usage, errType := state.Run(context.Background(), strings.NewReader(body))
 	_ = usage
 	if errType != "" {
 		t.Fatalf("stream errType=%q", errType)
@@ -164,17 +167,18 @@ func TestStreamReasoningContent(t *testing.T) {
 }
 
 func TestStreamSplitToolHeader(t *testing.T) {
-	// Some providers split id and name across chunks — args must buffer.
+	// Some providers split id and name across chunks — args must buffer, and
+	// the fragments must land in a single tool block.
 	evs := runStream(t, []string{
 		`{"id":"c4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","function":{"arguments":"{\"a\""}}]}}]}`,
 		`{"id":"c4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"late_name","arguments":":1}"}}]}}]}`,
 		`{"id":"c4","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
 	})
-	var opened string
+	var starts []map[string]any
 	var args string
 	for _, e := range evs {
 		if e.name == "content_block_start" {
-			opened = e.data["content_block"].(map[string]any)["name"].(string)
+			starts = append(starts, e.data["content_block"].(map[string]any))
 		}
 		if e.name == "content_block_delta" {
 			d := e.data["delta"].(map[string]any)
@@ -183,7 +187,112 @@ func TestStreamSplitToolHeader(t *testing.T) {
 			}
 		}
 	}
-	if opened != "late_name" || args != `{"a":1}` {
-		t.Errorf("opened=%q args=%q", opened, args)
+	if len(starts) != 1 {
+		t.Fatalf("expected 1 tool block, got %d: %s", len(starts), names(evs))
+	}
+	if starts[0]["name"] != "late_name" || starts[0]["id"] != "call_x" || args != `{"a":1}` {
+		t.Errorf("opened=%v args=%q", starts[0], args)
+	}
+}
+
+func TestStreamToolCallsWithoutIndex(t *testing.T) {
+	// Providers that omit tool_calls[].index (some xAI/OpenRouter/vLLM
+	// builds) signal a new call with a fresh id; args-only fragments carry
+	// neither and continue the open call.
+	evs := runStream(t, []string{
+		`{"id":"c5","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_a","function":{"name":"read_file","arguments":"{\"path\":"}}]}}]}`,
+		`{"id":"c5","choices":[{"index":0,"delta":{"tool_calls":[{"function":{"arguments":"\"a.go\"}"}}]}}]}`,
+		`{"id":"c5","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call_b","function":{"name":"bash","arguments":"{\"cmd\":\"ls\"}"}}]}}]}`,
+		`{"id":"c5","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	})
+	var starts []map[string]any
+	argsByIndex := map[float64]string{}
+	for _, e := range evs {
+		if e.name == "content_block_start" {
+			starts = append(starts, e.data["content_block"].(map[string]any))
+		}
+		if e.name == "content_block_delta" {
+			d := e.data["delta"].(map[string]any)
+			if d["type"] == "input_json_delta" {
+				argsByIndex[e.data["index"].(float64)] += d["partial_json"].(string)
+			}
+		}
+	}
+	if len(starts) != 2 {
+		t.Fatalf("expected 2 tool blocks, got %d: %s", len(starts), names(evs))
+	}
+	if starts[0]["name"] != "read_file" || starts[1]["name"] != "bash" {
+		t.Errorf("tool names: %v %v", starts[0]["name"], starts[1]["name"])
+	}
+	if argsByIndex[0] != `{"path":"a.go"}` || argsByIndex[1] != `{"cmd":"ls"}` {
+		t.Errorf("args split wrong: %v", argsByIndex)
+	}
+}
+
+func TestStreamCancellation(t *testing.T) {
+	// A stalled upstream (body that never produces a byte) must not hang Run
+	// past ctx cancellation.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	rec := httptest.NewRecorder()
+	state := newStreamState(anthropic.NewSSEWriter(rec), "gpt")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan string, 1)
+	go func() {
+		_, errType := state.Run(ctx, pr)
+		done <- errType
+	}()
+	cancel()
+	select {
+	case errType := <-done:
+		if errType != "client_disconnect" {
+			t.Errorf("errType = %q, want client_disconnect", errType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancellation")
+	}
+}
+
+func TestStreamKeepAliveBeforeFirstChunk(t *testing.T) {
+	// While the upstream is quiet before the first token, pings must flow so
+	// the client doesn't time out on a byte-silent connection.
+	pr, pw := io.Pipe()
+	rec := httptest.NewRecorder()
+	state := newStreamState(anthropic.NewSSEWriter(rec), "gpt")
+	state.keepAliveEvery = 5 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		state.Run(context.Background(), pr)
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	io.WriteString(pw, "data: {\"id\":\"c6\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+	pw.Close()
+	<-done
+
+	evs := parseEvents(t, rec.Body.String())
+	if len(evs) == 0 || evs[0].name != "message_start" {
+		t.Fatalf("first event should be message_start, got: %s", names(evs))
+	}
+	pings := 0
+	for _, e := range evs {
+		if e.name == "ping" {
+			pings++
+		}
+	}
+	if pings < 2 {
+		t.Errorf("expected keep-alive pings before first chunk, got %d", pings)
+	}
+	// The real chunk must not re-open the message.
+	startCount := 0
+	for _, e := range evs {
+		if e.name == "message_start" {
+			startCount++
+		}
+	}
+	if startCount != 1 {
+		t.Errorf("message_start emitted %d times", startCount)
 	}
 }

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -254,6 +254,30 @@ func TestStreamCancellation(t *testing.T) {
 	}
 }
 
+func TestStreamEmptyAfterKeepAlive(t *testing.T) {
+	// Upstream that goes quiet long enough for a keep-alive ping to open the
+	// message, then EOFs with zero chunks: still an error, not an empty
+	// message (Claude Code retries on the error event).
+	pr, pw := io.Pipe()
+	rec := httptest.NewRecorder()
+	state := newStreamState(anthropic.NewSSEWriter(rec), "gpt")
+	state.keepAliveEvery = 5 * time.Millisecond
+
+	done := make(chan string, 1)
+	go func() {
+		_, errType := state.Run(context.Background(), pr)
+		done <- errType
+	}()
+	time.Sleep(30 * time.Millisecond) // let a ping open the message
+	pw.Close()                        // EOF without a single chunk
+	if errType := <-done; errType != "api_error" {
+		t.Errorf("errType = %q, want api_error", errType)
+	}
+	if !strings.Contains(rec.Body.String(), "upstream produced no chunks") {
+		t.Errorf("expected no-chunks error event, got:\n%s", rec.Body.String())
+	}
+}
+
 func TestStreamKeepAliveBeforeFirstChunk(t *testing.T) {
 	// While the upstream is quiet before the first token, pings must flow so
 	// the client doesn't time out on a byte-silent connection.

--- a/internal/router/autogoal.go
+++ b/internal/router/autogoal.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/maorbril/agentic/internal/anthropic"
 	"github.com/maorbril/agentic/internal/config"
@@ -56,7 +57,11 @@ func (g *goalRouter) check(ctx context.Context, rule config.RouteRule, cfg *conf
 
 	summary := fmt.Sprintf("(conversation: %d messages, %d tools available)\n%s",
 		len(req.Messages), len(req.Tools), truncate(userText, 2000))
-	decision, err := g.classify(ctx, rule, cfg, summary)
+	// Bounded like tier routing (autoroute.go): this runs inline before the
+	// real upstream call, so a stuck classifier would stall the whole turn.
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	decision, err := g.classify(cctx, rule, cfg, summary)
 	if err != nil {
 		return false, "", true
 	}


### PR DESCRIPTION
## Problem

Subagent/tool turns routed to non-Anthropic models intermittently hung with no output until Claude Code's ~60s timeout fired and disconnected. `router.log` shows the signature: `status=499 in=0 out=0 ms=60001`.

## Root causes & fixes

**1. Auto Goal classification had no timeout** (`internal/router/autogoal.go`)

`goal.check` runs inline on every new user turn *before* the real upstream call, using the request's unbounded context. A slow/stuck classifier stalled the entire turn. Tier routing already bounds itself to 10s (`autoroute.go`); the goal path now does the same, failing open on timeout.

**2. OpenAI stream translation was silent and uncancellable** (`internal/backend/openaibe/stream.go`)

`Run` blocked on `bufio.Scanner` with no ctx awareness and wrote zero bytes to the client until the upstream's first chunk. Slow reasoning models can sit quiet for a minute before the first token — the client saw a byte-silent connection and gave up. Now:
- reads happen in a goroutine; the main loop selects on lines / `ctx.Done()` / a 15s keep-alive ticker
- before the first chunk, keep-alive opens the message with a synthetic id and pings
- client disconnects return promptly as `client_disconnect` / status 499 (previously logged as 200)

**3. Parallel tool calls collapsed when the provider omits `tool_calls[].index`**

Missing index defaulted to 0, so parallel tool calls merged into one block with concatenated JSON args — corrupting multi-tool (subagent fan-out) turns. New calls are now detected by fresh `id` when index is absent. Also fixes split id/name headers emitting a spurious `unknown_tool` block (the old test passed coincidentally; it now asserts exactly one block).

## Tests

- `TestStreamToolCallsWithoutIndex` — two no-index calls stay two blocks with correct args
- `TestStreamCancellation` — stalled upstream returns on ctx cancel
- `TestStreamKeepAliveBeforeFirstChunk` — pings flow before first token, single `message_start`
- `TestStreamSplitToolHeader` strengthened to count blocks
- `go test ./...` and `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)