### PR TITLE
Size-aware tier routing + dispatch-time prompt-too-long guard (Phase 3)

### DIFF
--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -16,6 +16,7 @@ var (
 	provBase   string
 	provKeyEnv string
 	provMaxTok string
+	provMaxReq int64
 )
 
 var providersCmd = &cobra.Command{
@@ -77,6 +78,9 @@ var providersAddCmd = &cobra.Command{
 		if provMaxTok != "" {
 			snippet += fmt.Sprintf("max_tokens_param: %s\n", provMaxTok)
 		}
+		if provMaxReq > 0 {
+			snippet += fmt.Sprintf("max_request_bytes: %d\n", provMaxReq)
+		}
 		return editConfig(func(doc *config.Doc) error {
 			return doc.SetSubtree("providers", args[0], snippet)
 		}, "provider "+args[0])
@@ -99,5 +103,6 @@ func init() {
 	providersAddCmd.Flags().StringVar(&provBase, "base-url", "", "API base URL")
 	providersAddCmd.Flags().StringVar(&provKeyEnv, "key-env", "", "env var holding the API key (empty = no auth)")
 	providersAddCmd.Flags().StringVar(&provMaxTok, "max-tokens-param", "", "max_tokens | max_completion_tokens")
+	providersAddCmd.Flags().Int64Var(&provMaxReq, "max-request-bytes", 0, "upstream request body cap in bytes (refuses oversized requests pre-dispatch; 0 = none)")
 	providersCmd.AddCommand(providersListCmd, providersAddCmd, providersRemoveCmd)
 }

--- a/cmd/statusline.go
+++ b/cmd/statusline.go
@@ -50,7 +50,7 @@ var statuslineCmd = &cobra.Command{
 		day, _ := st.TotalSince(dayStart, "", "")
 
 		modelPart := orDefault(input.Model.DisplayName, "?")
-		if alias, tier, model, ok, _ := st.LatestRouteDecision(sessionID); ok && alias == input.Model.DisplayName {
+		if alias, tier, model, _, ok, _ := st.LatestRouteDecision(sessionID); ok && alias == input.Model.DisplayName {
 			tierColor := map[string]string{
 				"deep":     "\033[35m", // magenta
 				"standard": "\033[36m", // cyan

--- a/docs/context-scaling.md
+++ b/docs/context-scaling.md
@@ -63,10 +63,32 @@ Rules of the lie:
 With `model: auto`, different turns land on models with different budgets.
 The gauge is always relative to the *current* model, so it can jump when
 the tier changes — a conversation at 30% of opus's budget may be 90% of a
-local model's. That jump is correct (it reflects real headroom) but it
-means a light-tier turn can trigger a compact a deep-tier turn wouldn't.
-Deterministic size-aware tier filtering (don't route a conversation to a
-model it doesn't fit) is Phase 3, not yet implemented.
+local model's. That jump is correct (it reflects real headroom).
+
+**Size-aware tier selection.** Before classifying, the router estimates the
+request's input size and filters out any tier whose budget can't hold input
+plus reserved output headroom. The classifier then runs over the survivors;
+if its pick was filtered out, it's remapped upward to the smallest tier that
+still fits. A mid-turn continuation that outgrew its tier is remapped the
+same way and pinned, so the rest of the turn stays on the larger tier. When
+only one tier fits, the classifier call is skipped entirely. Tiers without a
+declared `context_window` are treated as infinite (always eligible) — so a
+mix of sized and unsized models works, and all-anthropic routing is
+unaffected.
+
+**Dispatch guard.** Whatever the router settles on, a pre-dispatch check
+catches the hard-overflow case: if the resolved model has a known budget and
+the estimated input exceeds it (plus headroom), the request is refused with a
+`400 invalid_request_error` ("request too large for model context budget")
+before it reaches upstream — instead of a mangled, provider-specific failure.
+Claude Code treats the 400 as a terminal error (no retry-spin), which is why
+it's used over 413/429. The guard is skipped for `count_tokens` and for
+models with an unknown budget.
+
+Both behaviors are observable: the router logs `autoroute_size` (Debug) with
+the estimate, required tokens, excluded tiers, and the remap; `route_decisions`
+gains a `reason` column (`size:light→standard`, `size:sticky:light→standard`)
+visible via the statusline and `agentic context`.
 
 ## Evaluating it
 

--- a/docs/context-scaling.md
+++ b/docs/context-scaling.md
@@ -90,6 +90,24 @@ the estimate, required tokens, excluded tiers, and the remap; `route_decisions`
 gains a `reason` column (`size:light→standard`, `size:sticky:light→standard`)
 visible via the statusline and `agentic context`.
 
+**Request-body byte cap.** Separate from the token budget: some upstreams cap
+the raw request body size (e.g. an nginx `client_max_body_size`), and a body can
+blow that cap while still being token-small — most often with accumulated
+base64 images/attachments. Declare it on the provider:
+
+```yaml
+providers:
+  glm52: {type: openai, base_url: …, api_key_env: VLLM_API_KEY, max_request_bytes: 33554432} # 32 MiB
+```
+
+The router treats it like the token budget: a tier whose provider cap the body
+exceeds is filtered out before routing (so an image-heavy turn routes away from
+the capped provider), and a pre-dispatch guard refuses a body over the resolved
+provider's cap with a `400 invalid_request_error` ("request body too large … run
+/compact or remove images/attachments") instead of a mangled upstream 413 retry
+loop. Unknown cap (`0`) means no guard. `agentic providers add --max-request-bytes`
+sets it.
+
 ## Evaluating it
 
 Three layers, from cheap to real:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,12 @@ type Provider struct {
 	// MaxTokensParam is the OpenAI-dialect parameter name for the output
 	// limit: "max_tokens" (default) or "max_completion_tokens".
 	MaxTokensParam string `yaml:"max_tokens_param"`
+	// MaxRequestBytes is the upstream's request body size cap (e.g. an nginx
+	// client_max_body_size). A request larger than this is refused before
+	// dispatch with a clean 400 instead of a mangled upstream 413 retry loop.
+	// 0 means unknown/no cap. Sits on the provider because the cap belongs to
+	// the upstream edge, not the model.
+	MaxRequestBytes int `yaml:"max_request_bytes"`
 }
 
 // Key resolves the provider's API key: config literal, then process
@@ -194,6 +200,9 @@ func (c *Config) Validate() error {
 		}
 		if p.BaseURL == "" {
 			return fmt.Errorf("config: provider %q missing base_url", name)
+		}
+		if p.MaxRequestBytes < 0 {
+			return fmt.Errorf("config: provider %q has negative max_request_bytes", name)
 		}
 	}
 	for alias, m := range c.Models {

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -66,10 +66,10 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 		return rule.Tiers[fallback], fallback, ""
 	}
 
-	// Size-aware fit: which tiers can hold this request? Required==0 means
-	// no tier has a known budget — the backward-compat fast path (no
-	// estimate, no filtering).
-	fit := classifyTierFit(cfg, rule, req)
+	// Size-aware fit: which tiers can hold this request? Required==0 and no
+	// byte caps means no tier has a known limit — the backward-compat fast
+	// path (no estimate, no filtering).
+	fit := classifyTierFit(cfg, rule, req, int64(len(raw)))
 
 	userText, isNewTurn := lastUserText(req)
 	hash := hashText(userText)

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -23,6 +24,7 @@ import (
 // doesn't flip models mid-flight.
 type autoRouter struct {
 	classify func(ctx context.Context, rule config.RouteRule, cfg *config.Config, summary string) (string, error)
+	log      *slog.Logger
 
 	mu    sync.Mutex
 	cache map[string]decision // key: session id (or user-text hash when unattributed)
@@ -43,8 +45,11 @@ light: mechanical edits, renames, formatting, summaries, verifying provided outp
 Request to classify:
 `
 
-// route picks the concrete model alias for a dynamically-routed request.
-func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *config.Config, raw []byte, sessionID string) (alias, tier string) {
+// route picks the concrete model alias for a dynamically-routed request. The
+// returned reason is a free-text note for observability — non-empty when
+// size-aware routing remapped the classifier's choice (e.g.
+// "size:light→standard"); empty for a plain classifier decision.
+func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *config.Config, raw []byte, sessionID string) (alias, tier, reason string) {
 	fallback := rule.Default
 	if fallback == "" {
 		fallback = "standard"
@@ -58,8 +63,14 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 
 	req, err := anthropic.ParseRequest(raw)
 	if err != nil {
-		return rule.Tiers[fallback], fallback
+		return rule.Tiers[fallback], fallback, ""
 	}
+
+	// Size-aware fit: which tiers can hold this request? Required==0 means
+	// no tier has a known budget — the backward-compat fast path (no
+	// estimate, no filtering).
+	fit := classifyTierFit(cfg, rule, req)
+
 	userText, isNewTurn := lastUserText(req)
 	hash := hashText(userText)
 	key := sessionID
@@ -75,11 +86,28 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 	// turn keep the tier that opened the turn.
 	if hasPrev && (!isNewTurn || prev.userHash == hash) {
 		if _, ok := rule.Tiers[prev.tier]; ok {
-			return rule.Tiers[prev.tier], prev.tier
+			if fit.Eligible[prev.tier] {
+				return rule.Tiers[prev.tier], prev.tier, ""
+			}
+			// The sticky tier can't hold this (larger) continuation.
+			// Remap upward without re-classifying, and pin the cache so the
+			// rest of the turn stays on the remapped tier.
+			remapped := remapTier(cfg, rule, fit, prev.tier)
+			a.logFit(rule, fit, prev.tier, remapped, "sticky")
+			a.cacheDecision(key, hash, remapped)
+			return rule.Tiers[remapped], remapped, "size:sticky:" + prev.tier + "→" + remapped
 		}
 	}
 	if userText == "" {
-		return rule.Tiers[fallback], fallback
+		return rule.Tiers[fallback], fallback, ""
+	}
+
+	// When size filtering has left exactly one viable tier, skip the
+	// classifier call — there's nothing to decide.
+	if t, ok := onlyEligibleTier(fit); ok {
+		a.logFit(rule, fit, "", t, "only")
+		a.cacheDecision(key, hash, t)
+		return rule.Tiers[t], t, ""
 	}
 
 	summary := fmt.Sprintf("(conversation: %d messages, %d tools available)\n%s",
@@ -91,13 +119,45 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 		tier = fallback
 	}
 
+	// The classifier has no notion of size; if it picked a tier the request
+	// won't fit, remap upward to the smallest tier that does.
+	if fit.Required > 0 && !fit.Eligible[tier] {
+		chosen := tier
+		tier = remapTier(cfg, rule, fit, chosen)
+		a.logFit(rule, fit, chosen, tier, "remap")
+		reason = "size:" + chosen + "→" + tier
+	}
+
+	a.cacheDecision(key, hash, tier)
+	return rule.Tiers[tier], tier, reason
+}
+
+// cacheDecision stores a tier decision under key, flushing the cache when it
+// exceeds 1000 entries.
+func (a *autoRouter) cacheDecision(key, hash, tier string) {
 	a.mu.Lock()
 	if len(a.cache) > 1000 {
 		a.cache = map[string]decision{}
 	}
 	a.cache[key] = decision{userHash: hash, tier: tier, at: time.Now()}
 	a.mu.Unlock()
-	return rule.Tiers[tier], tier
+}
+
+// logFit emits a Debug-level autoroute_size event when size filtering is
+// active. from is the classifier-chosen (or sticky) tier; to is the tier
+// actually used. kind is "sticky" | "only" | "remap".
+func (a *autoRouter) logFit(rule config.RouteRule, fit fitDecision, from, to, kind string) {
+	if a.log == nil {
+		return
+	}
+	a.log.Debug("autoroute_size",
+		"estimated_input", fit.EstInput,
+		"required", fit.Required,
+		"excluded", fit.Filtered,
+		"from", from,
+		"to", to,
+		"kind", kind,
+	)
 }
 
 // lastUserText returns the newest user-authored text and whether the last

--- a/internal/router/autoroute_test.go
+++ b/internal/router/autoroute_test.go
@@ -33,7 +33,7 @@ func body(msgs string) []byte {
 func TestAutoRouteClassifiesNewTurn(t *testing.T) {
 	calls := 0
 	a := newAuto("deep", nil, &calls)
-	alias, tier := a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"design the architecture for a big refactor"}`), "s1")
+	alias, tier, _ := a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"design the architecture for a big refactor"}`), "s1")
 	if alias != "opus" || tier != "deep" || calls != 1 {
 		t.Errorf("alias=%s tier=%s calls=%d", alias, tier, calls)
 	}
@@ -49,7 +49,7 @@ func TestAutoRouteSticksWithinTurn(t *testing.T) {
 	continuation := body(`{"role":"user","content":"plan the migration"},
 	  {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"read_file","input":{}}]},
 	  {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"data"}]}`)
-	alias, tier := a.route(context.Background(), testRule(), nil, continuation, "s1")
+	alias, tier, _ := a.route(context.Background(), testRule(), nil, continuation, "s1")
 	if alias != "opus" || tier != "deep" {
 		t.Errorf("continuation: alias=%s tier=%s", alias, tier)
 	}
@@ -62,7 +62,7 @@ func TestAutoRouteSticksWithinTurn(t *testing.T) {
 		calls++
 		return "light", nil
 	}
-	alias, tier = a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"rename that variable"}`), "s1")
+	alias, tier, _ = a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"rename that variable"}`), "s1")
 	if alias != "qwen" || tier != "light" || calls != 2 {
 		t.Errorf("new turn: alias=%s tier=%s calls=%d", alias, tier, calls)
 	}
@@ -71,14 +71,14 @@ func TestAutoRouteSticksWithinTurn(t *testing.T) {
 func TestAutoRouteFallsBackOnFailure(t *testing.T) {
 	calls := 0
 	a := newAuto("", errors.New("classifier down"), &calls)
-	alias, tier := a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"hello"}`), "s2")
+	alias, tier, _ := a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"hello"}`), "s2")
 	if alias != "sonnet" || tier != "standard" {
 		t.Errorf("fallback: alias=%s tier=%s", alias, tier)
 	}
 
 	// Garbage classifier answer also falls back.
 	a = newAuto("banana", nil, &calls)
-	alias, tier = a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"hello"}`), "s3")
+	alias, tier, _ = a.route(context.Background(), testRule(), nil, body(`{"role":"user","content":"hello"}`), "s3")
 	if alias != "sonnet" || tier != "standard" {
 		t.Errorf("garbage answer: alias=%s tier=%s", alias, tier)
 	}
@@ -132,4 +132,143 @@ routing:
 			t.Errorf("%s: expected validation error", name)
 		}
 	}
+}
+
+// --- Phase 3: size-aware routing ---
+
+func sizedRule() config.RouteRule {
+	return config.RouteRule{
+		Classifier: "cheap",
+		Default:    "standard",
+		Tiers:      map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"},
+	}
+}
+
+// bigBody builds a request whose estimated input exceeds the 8K "light" tier
+// but fits the 32K "standard" tier.
+func bigBody(msgs string) []byte {
+	// ~30000 tokens of padding in the user message.
+	padding := repeat("w ", 30000)
+	return []byte(`{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + msgs + padding + `"}]}`)
+}
+
+func TestAutoRouteSizeRemapsUpFromLight(t *testing.T) {
+	calls := 0
+	a := newAuto("light", nil, &calls)
+	alias, tier, reason := a.route(context.Background(), sizedRule(), sizedCfg(), bigBody("plan "), "s1")
+	if tier != "standard" || alias != "sonnet" {
+		t.Errorf("remapped to tier=%s alias=%s, want standard/sonnet", tier, alias)
+	}
+	if reason == "" || !contains(reason, "light→standard") {
+		t.Errorf("reason=%q should record light→standard", reason)
+	}
+}
+
+func TestAutoRouteSizeRemapPicksSmallest(t *testing.T) {
+	// Fits 32K (standard) and 128K (deep) but not 8K (light). Classifier picks
+	// light; remap must choose standard (smallest fitting), not deep.
+	calls := 0
+	a := newAuto("light", nil, &calls)
+	_, tier, _ := a.route(context.Background(), sizedRule(), sizedCfg(), bigBody("plan "), "s1")
+	if tier != "standard" {
+		t.Errorf("remap = %s, want standard (smallest that fits)", tier)
+	}
+}
+
+func TestAutoRouteSizeOnlyEligibleSkipsClassifier(t *testing.T) {
+	// So large only opus (128K) fits → classifier must not run, opus is chosen directly.
+	calls := 0
+	a := newAuto("standard", nil, &calls) // would pick standard if called
+	huge := []byte(`{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + repeat("w ", 80000) + `"}]}`)
+	alias, tier, reason := a.route(context.Background(), sizedRule(), sizedCfg(), huge, "s1")
+	if tier != "deep" || alias != "opus" {
+		t.Errorf("only-eligible = tier=%s alias=%s, want deep/opus", tier, alias)
+	}
+	if calls != 0 {
+		t.Errorf("classifier ran %d times; with one eligible tier it must be skipped", calls)
+	}
+	if reason != "" {
+		t.Errorf("reason=%q should be empty (no remap, just skipped classify)", reason)
+	}
+}
+
+func TestAutoRouteStickyButTooBigRemaps(t *testing.T) {
+	calls := 0
+	a := newAuto("light", nil, &calls)
+	// Turn 1: small request, classifier picks light (qwen 8K). Decision cached.
+	small := body(`{"role":"user","content":"hi"}`)
+	a.route(context.Background(), sizedRule(), sizedCfg(), small, "s1")
+	if calls != 1 {
+		t.Fatalf("turn 1: calls=%d want 1", calls)
+	}
+	// Continuation of the same turn (no new user text) but grown past 8K.
+	continuation := []byte(`{"model":"auto","max_tokens":100,"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"read","input":{}}]},
+		{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"` + repeat("w ", 30000) + `"}]}
+	]}`)
+	alias, tier, reason := a.route(context.Background(), sizedRule(), sizedCfg(), continuation, "s1")
+	if tier != "standard" || alias != "sonnet" {
+		t.Errorf("sticky overflow: tier=%s alias=%s, want standard/sonnet", tier, alias)
+	}
+	if calls != 1 {
+		t.Errorf("continuation must not re-classify: calls=%d want 1", calls)
+	}
+	if reason == "" || !contains(reason, "sticky") {
+		t.Errorf("reason=%q should note sticky remap", reason)
+	}
+	// Cache was updated: a further continuation sticks to standard, not light.
+	again := continuation
+	alias, tier, _ = a.route(context.Background(), sizedRule(), sizedCfg(), again, "s1")
+	if tier != "standard" {
+		t.Errorf("after sticky remap, further continuation tier=%s want standard", tier)
+	}
+}
+
+func TestAutoRouteUnknownBudgetEligible(t *testing.T) {
+	// deep tier has no context_window (infinite); others small. Oversized request
+	// overflows standard+light, so it must route to the unknown-budget deep.
+	cfg := sizedCfg()
+	rule := config.RouteRule{
+		Classifier: "cheap", Default: "standard",
+		Tiers: map[string]string{"deep": "unknown", "standard": "sonnet", "light": "qwen"},
+	}
+	calls := 0
+	a := newAuto("light", nil, &calls)
+	huge := []byte(`{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + repeat("w ", 80000) + `"}]}`)
+	alias, tier, _ := a.route(context.Background(), rule, cfg, huge, "s1")
+	if tier != "deep" || alias != "unknown" {
+		t.Errorf("unknown-budget eligible: tier=%s alias=%s, want deep/unknown", tier, alias)
+	}
+}
+
+func TestAutoRouteNoBudgetsNoFiltering(t *testing.T) {
+	// No budgets anywhere → classifier answer honored unchanged (backward compat).
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{"fake": {Type: config.ProviderOpenAI, BaseURL: "http://x"}},
+		Models: map[string]config.Model{
+			"opus": {Provider: "fake", ID: "opus-up"}, "sonnet": {Provider: "fake", ID: "sonnet-up"},
+		},
+	}
+	rule := config.RouteRule{Classifier: "cheap", Default: "standard",
+		Tiers: map[string]string{"deep": "opus", "standard": "sonnet"}}
+	calls := 0
+	a := newAuto("light", nil, &calls) // garbage tier (not in rule) → falls back to standard
+	alias, tier, reason := a.route(context.Background(), rule, cfg, bigBody("hi"), "s1")
+	if tier != "standard" || alias != "sonnet" {
+		t.Errorf("no-budgets: tier=%s alias=%s, want standard/sonnet (fallback)", tier, alias)
+	}
+	if reason != "" {
+		t.Errorf("no-budgets reason=%q should be empty", reason)
+	}
+}
+
+func contains(s, sub string) bool { return len(s) >= len(sub) && indexOf(s, sub) >= 0 }
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -170,6 +170,20 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 					return
 				}
 			}
+			// Request body byte cap (e.g. an upstream nginx limit). Refuse
+			// oversized bodies — common with accumulated images/attachments —
+			// before dispatch, instead of a mangled upstream 413 retry loop.
+			if tooLarge, size, cap := bodyTooLarge(route, int64(len(raw))); tooLarge {
+				msg := fmt.Sprintf("agentic: request body too large for provider %q "+
+					"(%d bytes exceeds max_request_bytes %d); "+
+					"run /compact or remove images/attachments",
+					route.ProviderName, size, cap)
+				anthropic.WriteError(w, 400, "invalid_request_error", msg)
+				s.log.Info("request_too_large",
+					"model", route.Model.ID, "alias", resolveAlias,
+					"bytes", size, "max_request_bytes", cap)
+				return
+			}
 		}
 
 		profile := r.Header.Get("X-Agentic-Profile")

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -45,7 +45,7 @@ func NewServer(cfg *config.Config, token, dataDir string, st *store.Store, logge
 	s.cfg.Store(cfg)
 	s.pricing.Store(pricing.Load(dataDir, cfg))
 	s.gate = budget.NewGate(cfg, st, logger)
-	s.auto = &autoRouter{classify: s.classifyViaBackend, cache: map[string]decision{}}
+	s.auto = &autoRouter{classify: s.classifyViaBackend, cache: map[string]decision{}, log: logger}
 	s.goal = &goalRouter{classify: s.classifyGoalViaBackend}
 	return s
 }
@@ -120,11 +120,11 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 		sessionID := r.Header.Get("X-Agentic-Session")
 		resolveAlias := env.Model
 		if rule, ok := cfg.Routing[env.Model]; ok {
-			chosen, tier := s.auto.route(r.Context(), rule, cfg, raw, sessionID)
-			s.log.Info("autoroute", "alias", env.Model, "tier", tier, "model", chosen)
+			chosen, tier, reason := s.auto.route(r.Context(), rule, cfg, raw, sessionID)
+			s.log.Info("autoroute", "alias", env.Model, "tier", tier, "model", chosen, "reason", reason)
 			resolveAlias = chosen
 			if sessionID != "" {
-				if err := s.store.RecordRouteDecision(sessionID, env.Model, tier, chosen, time.Now()); err != nil {
+				if err := s.store.RecordRouteDecision(sessionID, env.Model, tier, chosen, reason, time.Now()); err != nil {
 					s.log.Warn("route decision insert failed", "err", err)
 				}
 				worthy, reason, isNewTurn := s.goal.check(r.Context(), rule, cfg, raw, sessionID)
@@ -149,6 +149,27 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 		if err != nil {
 			anthropic.WriteError(w, 404, "not_found_error", "agentic: "+err.Error()+" (see ~/.agentic/config.yaml)")
 			return
+		}
+
+		// Dispatch-time prompt-too-long guard: for a model with a known
+		// context budget, refuse requests the budget can't hold before they
+		// reach upstream and fail with a mangled, provider-specific error.
+		// 400 (not 413) so Claude Code doesn't retry-spin — same rationale as
+		// the budget gate below. count_tokens never dispatches, so skip it.
+		if !countTokens {
+			if req, perr := anthropic.ParseRequest(raw); perr == nil {
+				if overflow, required, budget := promptTooLong(route, req); overflow {
+					msg := fmt.Sprintf("agentic: request too large for model %q context budget "+
+						"(estimated %d + reserved output exceeds budget %d); "+
+						"reduce the conversation or switch models",
+						route.Model.ID, required, budget)
+					anthropic.WriteError(w, 400, "invalid_request_error", msg)
+					s.log.Info("prompt_too_long",
+						"model", route.Model.ID, "alias", resolveAlias,
+						"estimated_input", required, "budget", budget)
+					return
+				}
+			}
 		}
 
 		profile := r.Header.Get("X-Agentic-Profile")

--- a/internal/router/server_test.go
+++ b/internal/router/server_test.go
@@ -180,7 +180,7 @@ func TestAutoRouteEndToEnd(t *testing.T) {
 	}
 
 	// The routing decision is persisted so the statusline can show it.
-	alias, tier, model, ok, err := st.LatestRouteDecision("sess-test")
+	alias, tier, model, _, ok, err := st.LatestRouteDecision("sess-test")
 	if err != nil || !ok || alias != "auto" || tier != "deep" || model != "big" {
 		t.Errorf("route decision: alias=%s tier=%s model=%s ok=%v err=%v, want auto/deep/big/true/nil",
 			alias, tier, model, ok, err)

--- a/internal/router/size.go
+++ b/internal/router/size.go
@@ -1,0 +1,200 @@
+package router
+
+import (
+	"math"
+	"sort"
+
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/config"
+	"github.com/maorbril/agentic/internal/tokens"
+)
+
+// defaultReservedOutput is the output headroom reserved when neither the
+// request's max_tokens nor the model's MaxOutput constrains it. Sits in the
+// router (not tokens) because it is a routing/dispatch policy, not an
+// estimator property. Tunable: smaller = tighter fit (more remapping), larger
+// = safer (more conservative).
+const defaultReservedOutput = 8192
+
+// reservedOutput returns the output headroom to reserve when testing whether
+// a request fits a context budget. Prefers the request's own max_tokens
+// (what the model will actually try to produce), caps it against the model's
+// MaxOutput, and falls back to defaultReservedOutput when neither applies.
+func reservedOutput(reqMaxTokens, modelMaxOutput int) int {
+	r := reqMaxTokens
+	if modelMaxOutput > 0 && (r == 0 || r > modelMaxOutput) {
+		r = modelMaxOutput
+	}
+	if r <= 0 {
+		return defaultReservedOutput
+	}
+	return r
+}
+
+// tierBudget resolves the context budget for a tier's model alias. Returns 0
+// when the budget is unknown (the tier is then treated as having infinite
+// capacity) or the alias fails to resolve (defensive — config validation
+// should prevent that).
+func tierBudget(cfg *config.Config, alias string) int {
+	if cfg == nil {
+		return 0
+	}
+	r, err := cfg.Resolve(alias)
+	if err != nil {
+		return 0
+	}
+	return r.Model.ContextBudget()
+}
+
+// fitDecision summarizes the size-aware filtering of a route rule's tiers.
+type fitDecision struct {
+	Eligible map[string]bool // tier name -> fits (budget unknown => true)
+	Required int64           // estimated input + reserved output; 0 when no estimate
+	EstInput int64           // the estimate, or 0 when no tier had a known budget
+	Filtered []string        // tiers excluded because they don't fit (sorted)
+}
+
+// classifyTierFit computes which tiers can hold the request. When no tier has
+// a known budget, it returns every tier eligible with Required==0 and computes
+// no estimate — the backward-compat fast path (all pre-Phase-3 configs).
+func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.MessagesRequest) fitDecision {
+	elig := map[string]bool{}
+	for t := range rule.Tiers {
+		elig[t] = true
+	}
+
+	anyKnown := false
+	for _, alias := range rule.Tiers {
+		if tierBudget(cfg, alias) > 0 {
+			anyKnown = true
+			break
+		}
+	}
+	if !anyKnown {
+		return fitDecision{Eligible: elig}
+	}
+
+	est := tokens.Estimate(req)
+	// Shared output cap: the largest MaxOutput among tiers, conservative (bias
+	// toward over-reserving, which biases toward remapping up — safe).
+	maxCap := 0
+	for _, alias := range rule.Tiers {
+		if m, ok := cfg.Models[alias]; ok && m.MaxOutput > maxCap {
+			maxCap = m.MaxOutput
+		}
+	}
+	reqMax := 0
+	if req != nil {
+		reqMax = req.MaxTokens
+	}
+	required := est + int64(reservedOutput(reqMax, maxCap))
+
+	var filtered []string
+	for tier, alias := range rule.Tiers {
+		b := tierBudget(cfg, alias)
+		if b == 0 || required <= int64(b) {
+			elig[tier] = true
+		} else {
+			elig[tier] = false
+			filtered = append(filtered, tier)
+		}
+	}
+	sort.Strings(filtered)
+	return fitDecision{Eligible: elig, Required: required, EstInput: est, Filtered: filtered}
+}
+
+// onlyEligibleTier returns the single eligible tier when exactly one remains,
+// and ok=true. Used to skip the classifier call when size filtering has left
+// only one viable tier.
+func onlyEligibleTier(fit fitDecision) (tier string, ok bool) {
+	if fit.Required == 0 {
+		return "", false // filtering inactive
+	}
+	for t, ok2 := range fit.Eligible {
+		if ok2 {
+			if ok {
+				return "", false // more than one eligible
+			}
+			tier, ok = t, true
+		}
+	}
+	return tier, ok
+}
+
+// remapTier takes a classifier-chosen tier that was filtered out by fit and
+// returns the smallest-budget tier that still fits. Tiers with an unknown
+// budget (infinite) are preferred over overflow but not chosen as "smallest
+// that fits" when a known-budget tier fits. If nothing fits, returns the
+// largest-budget tier (best-effort) so the request still dispatches — the
+// dispatch guard then returns a clean error if it truly can't fit. A tier
+// that is already eligible is returned unchanged.
+func remapTier(cfg *config.Config, rule config.RouteRule, fit fitDecision, chosen string) string {
+	if fit.Eligible[chosen] {
+		return chosen
+	}
+	type cand struct {
+		tier   string
+		budget int
+	}
+	var known []cand
+	var unknown []string
+	for tier := range fit.Eligible {
+		if !fit.Eligible[tier] {
+			continue
+		}
+		b := tierBudget(cfg, rule.Tiers[tier])
+		if b > 0 {
+			known = append(known, cand{tier, b})
+		} else {
+			unknown = append(unknown, tier)
+		}
+	}
+	// Smallest known budget that fits.
+	if len(known) > 0 {
+		sort.Slice(known, func(i, j int) bool { return known[i].budget < known[j].budget })
+		return known[0].tier
+	}
+	// Nothing known fits — prefer an unknown-budget (infinite) tier.
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return unknown[0]
+	}
+	// Nothing fits at all — largest known budget, best-effort.
+	var all []cand
+	for tier, alias := range rule.Tiers {
+		if b := tierBudget(cfg, alias); b > 0 {
+			all = append(all, cand{tier, b})
+		}
+	}
+	if len(all) == 0 {
+		return chosen // no known budgets anywhere; nothing to remap to
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].budget > all[j].budget })
+	return all[0].tier
+}
+
+// promptTooLong reports whether the resolved model has a known context budget
+// that the estimated input (plus reserved output headroom) exceeds. Returns
+// false when the budget is unknown (no guard) or the request fits. required is
+// the estimated input + reserved output, budget the model's context budget.
+func promptTooLong(route config.Resolved, req *anthropic.MessagesRequest) (overflow bool, required int64, budget int) {
+	budget = route.Model.ContextBudget()
+	if budget <= 0 {
+		return false, 0, 0
+	}
+	reqMax := 0
+	if req != nil {
+		reqMax = req.MaxTokens
+	}
+	required = tokens.Estimate(req) + int64(reservedOutput(reqMax, route.Model.MaxOutput))
+	return required > int64(budget), required, budget
+}
+
+// budgetSortKey orders budgets ascending with unknown (0) treated as +Inf,
+// so known budgets sort first and unknown last.
+func budgetSortKey(b int) int {
+	if b <= 0 {
+		return math.MaxInt
+	}
+	return b
+}

--- a/internal/router/size.go
+++ b/internal/router/size.go
@@ -46,32 +46,50 @@ func tierBudget(cfg *config.Config, alias string) int {
 	return r.Model.ContextBudget()
 }
 
-// fitDecision summarizes the size-aware filtering of a route rule's tiers.
-type fitDecision struct {
-	Eligible map[string]bool // tier name -> fits (budget unknown => true)
-	Required int64           // estimated input + reserved output; 0 when no estimate
-	EstInput int64           // the estimate, or 0 when no tier had a known budget
-	Filtered []string        // tiers excluded because they don't fit (sorted)
+// tierMaxRequestBytes resolves the request-body byte cap for a tier's provider.
+// Returns 0 when unknown (no cap) or the alias fails to resolve.
+func tierMaxRequestBytes(cfg *config.Config, alias string) int {
+	if cfg == nil {
+		return 0
+	}
+	r, err := cfg.Resolve(alias)
+	if err != nil {
+		return 0
+	}
+	return r.Provider.MaxRequestBytes
 }
 
-// classifyTierFit computes which tiers can hold the request. When no tier has
-// a known budget, it returns every tier eligible with Required==0 and computes
-// no estimate — the backward-compat fast path (all pre-Phase-3 configs).
-func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.MessagesRequest) fitDecision {
+// fitDecision summarizes the size-aware filtering of a route rule's tiers.
+type fitDecision struct {
+	Eligible  map[string]bool // tier name -> fits (budget/bytes unknown => true)
+	Required  int64           // estimated input + reserved output; 0 when no estimate
+	EstInput  int64           // the estimate, or 0 when no tier had a known budget
+	BodyBytes int64           // raw request body size, for byte-cap filtering
+	Filtered  []string        // tiers excluded because they don't fit (sorted)
+}
+
+// classifyTierFit computes which tiers can hold the request. A tier is eligible
+// only if it fits BOTH the token budget and the provider's request-byte cap
+// (where either is known). When no tier has any known limit, it returns every
+// tier eligible with Required==0 — the backward-compat fast path.
+func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.MessagesRequest, bodyBytes int64) fitDecision {
 	elig := map[string]bool{}
 	for t := range rule.Tiers {
 		elig[t] = true
 	}
 
-	anyKnown := false
+	anyTokenKnown := false
+	anyByteKnown := false
 	for _, alias := range rule.Tiers {
 		if tierBudget(cfg, alias) > 0 {
-			anyKnown = true
-			break
+			anyTokenKnown = true
+		}
+		if tierMaxRequestBytes(cfg, alias) > 0 {
+			anyByteKnown = true
 		}
 	}
-	if !anyKnown {
-		return fitDecision{Eligible: elig}
+	if !anyTokenKnown && !anyByteKnown {
+		return fitDecision{Eligible: elig, BodyBytes: bodyBytes}
 	}
 
 	est := tokens.Estimate(req)
@@ -91,23 +109,28 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 
 	var filtered []string
 	for tier, alias := range rule.Tiers {
-		b := tierBudget(cfg, alias)
-		if b == 0 || required <= int64(b) {
-			elig[tier] = true
-		} else {
-			elig[tier] = false
+		fits := true
+		if b := tierBudget(cfg, alias); b > 0 && required > int64(b) {
+			fits = false
+		}
+		if mb := tierMaxRequestBytes(cfg, alias); mb > 0 && bodyBytes > int64(mb) {
+			fits = false
+		}
+		elig[tier] = fits
+		if !fits {
 			filtered = append(filtered, tier)
 		}
 	}
 	sort.Strings(filtered)
-	return fitDecision{Eligible: elig, Required: required, EstInput: est, Filtered: filtered}
+	return fitDecision{Eligible: elig, Required: required, EstInput: est, BodyBytes: bodyBytes, Filtered: filtered}
 }
 
 // onlyEligibleTier returns the single eligible tier when exactly one remains,
 // and ok=true. Used to skip the classifier call when size filtering has left
-// only one viable tier.
+// only one viable tier. Inactive when no filtering is active (Required==0 and
+// no byte filtering occurred).
 func onlyEligibleTier(fit fitDecision) (tier string, ok bool) {
-	if fit.Required == 0 {
+	if fit.Required == 0 && len(fit.Filtered) == 0 {
 		return "", false // filtering inactive
 	}
 	for t, ok2 := range fit.Eligible {
@@ -188,6 +211,33 @@ func promptTooLong(route config.Resolved, req *anthropic.MessagesRequest) (overf
 	}
 	required = tokens.Estimate(req) + int64(reservedOutput(reqMax, route.Model.MaxOutput))
 	return required > int64(budget), required, budget
+}
+
+// bodyTooLarge reports whether the resolved model's provider has a known
+// request-byte cap that the raw body exceeds. Returns false when the cap is
+// unknown (no guard). Used as a pre-dispatch guard so an oversized body —
+// common with accumulated images/attachments — is refused with a clean 400
+// instead of a mangled upstream 413 retry loop.
+func bodyTooLarge(route config.Resolved, bodyBytes int64) (tooLarge bool, size int64, cap int) {
+	cap = route.Provider.MaxRequestBytes
+	if cap <= 0 {
+		return false, 0, 0
+	}
+	return bodyBytes > int64(cap), bodyBytes, cap
+}
+
+// requestFits reports whether a resolved model can serve a request of the
+// given token requirement and body size. False when either the token budget or
+// the byte cap (where known) is exceeded. Used by the dispatch guard to cover
+// both limits in one check.
+func requestFits(route config.Resolved, req *anthropic.MessagesRequest, bodyBytes int64) bool {
+	if overflow, _, _ := promptTooLong(route, req); overflow {
+		return false
+	}
+	if tooLarge, _, _ := bodyTooLarge(route, bodyBytes); tooLarge {
+		return false
+	}
+	return true
 }
 
 // budgetSortKey orders budgets ascending with unknown (0) treated as +Inf,

--- a/internal/router/size_e2e_test.go
+++ b/internal/router/size_e2e_test.go
@@ -1,0 +1,181 @@
+package router
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maorbril/agentic/internal/config"
+	"github.com/maorbril/agentic/internal/store"
+)
+
+// newSizedServer builds a router whose "tiny" model has a 1000-token budget,
+// backed by an upstream that fails the test if reached.
+func newSizedServer(t *testing.T, reachedUpstream *bool) *httptest.Server {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reachedUpstream = true
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"id":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{"fake": {Type: config.ProviderOpenAI, BaseURL: upstream.URL}},
+		Models: map[string]config.Model{
+			"tiny":    {Provider: "fake", ID: "tiny-up", ContextWindow: 1000},
+			"unknown": {Provider: "fake", ID: "unknown-up"}, // no budget
+		},
+		Profiles: map[string]config.Profile{"main": {Model: "tiny"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestPromptTooLongGuard(t *testing.T) {
+	reached := false
+	ts := newSizedServer(t, &reached)
+
+	// Oversized: ~7000 tokens, far over the 1000 budget + reserved output.
+	big := `{"model":"tiny","max_tokens":50,"messages":[{"role":"user","content":"` + strings.Repeat("word ", 7000) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages", testToken, big)
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+	for _, want := range []string{"invalid_request_error", "too large", "context budget"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q: %s", want, body)
+		}
+	}
+	if reached {
+		t.Error("oversized request must not reach upstream")
+	}
+
+	// Small request to the same server passes (no false positive).
+	reached = false
+	resp, body = post(t, ts.URL+"/v1/messages", testToken,
+		`{"model":"tiny","max_tokens":50,"messages":[{"role":"user","content":"hello"}]}`)
+	if resp.StatusCode != 200 {
+		t.Fatalf("small request status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if !reached {
+		t.Error("small request should reach upstream")
+	}
+}
+
+func TestPromptTooLongGuardSkipsUnknownBudget(t *testing.T) {
+	reached := false
+	ts := newSizedServer(t, &reached)
+
+	// "unknown" model has no context_window → guard is a no-op even for a big request.
+	big := `{"model":"unknown","max_tokens":50,"messages":[{"role":"user","content":"` + strings.Repeat("word ", 7000) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages", testToken, big)
+	if resp.StatusCode != 200 {
+		t.Fatalf("unknown-budget status = %d, want 200 (guard skipped); body: %s", resp.StatusCode, body)
+	}
+	if !reached {
+		t.Error("unknown-budget request should reach upstream")
+	}
+}
+
+func TestCountTokensSkipsPromptGuard(t *testing.T) {
+	reached := false
+	ts := newSizedServer(t, &reached)
+
+	big := `{"model":"tiny","messages":[{"role":"user","content":"` + strings.Repeat("word ", 7000) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages/count_tokens", testToken, big)
+	if resp.StatusCode != 200 {
+		t.Fatalf("count_tokens status = %d, want 200 (guard skipped); body: %s", resp.StatusCode, body)
+	}
+	if reached {
+		t.Error("count_tokens must never reach upstream")
+	}
+	if !strings.Contains(body, "input_tokens") {
+		t.Errorf("body: %s", body)
+	}
+}
+
+// TestAutoRouteSizeRemapEndToEnd: a routing rule with 8K/32K/128K tiers; the
+// classifier picks "light" but the oversized request fits only standard+deep,
+// so the routed call must land on the standard upstream with a size reason.
+func TestAutoRouteSizeRemapEndToEnd(t *testing.T) {
+	var seenModels []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Model string `json:"model"`
+		}
+		json.Unmarshal(body, &req)
+		seenModels = append(seenModels, req.Model)
+		w.Header().Set("Content-Type", "application/json")
+		if req.Model == "classifier-up" {
+			io.WriteString(w, `{"id":"c","choices":[{"index":0,"message":{"role":"assistant","content":"light"},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":1}}`)
+			return
+		}
+		io.WriteString(w, `{"id":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	}))
+	defer upstream.Close()
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{"fake": {Type: config.ProviderOpenAI, BaseURL: upstream.URL}},
+		Models: map[string]config.Model{
+			"cheap": {Provider: "fake", ID: "classifier-up"},
+			"big":   {Provider: "fake", ID: "deep-up", ContextWindow: 128000},
+			"med":   {Provider: "fake", ID: "standard-up", ContextWindow: 32000},
+			"small": {Provider: "fake", ID: "light-up", ContextWindow: 8000},
+		},
+		Routing: map[string]config.RouteRule{
+			"auto": {Classifier: "cheap", Default: "standard",
+				Tiers: map[string]string{"deep": "big", "standard": "med", "light": "small"}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Oversized to 8K (light), fits 32K (standard): ~9400 estimated tokens.
+	big := `{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + strings.Repeat("word ", 6000) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages", testToken, big)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+	// classifier call, then the routed call to the standard (med) upstream.
+	if len(seenModels) < 2 || seenModels[len(seenModels)-1] != "standard-up" {
+		t.Errorf("routed to %v, want last call to standard-up", seenModels)
+	}
+	alias, tier, model, reason, ok, err := st.LatestRouteDecision("sess-test")
+	if err != nil || !ok {
+		t.Fatalf("no route decision recorded: ok=%v err=%v", ok, err)
+	}
+	if tier != "standard" || model != "med" {
+		t.Errorf("decision: alias=%s tier=%s model=%s, want tier=standard model=med", alias, tier, model)
+	}
+	if !strings.Contains(reason, "size") || !strings.Contains(reason, "light→standard") {
+		t.Errorf("reason=%q should record size:light→standard", reason)
+	}
+}

--- a/internal/router/size_e2e_test.go
+++ b/internal/router/size_e2e_test.go
@@ -179,3 +179,130 @@ func TestAutoRouteSizeRemapEndToEnd(t *testing.T) {
 		t.Errorf("reason=%q should record size:light→standard", reason)
 	}
 }
+
+// TestRequestBodyGuard: a provider with max_request_bytes refuses an oversized
+// body with a clean 400 before upstream; a small body passes.
+func TestRequestBodyGuard(t *testing.T) {
+	reached := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"id":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"fake":   {Type: config.ProviderOpenAI, BaseURL: upstream.URL},
+			"capped": {Type: config.ProviderOpenAI, BaseURL: upstream.URL, MaxRequestBytes: 1024},
+		},
+		Models:   map[string]config.Model{"capped-model": {Provider: "capped", ID: "capped-up"}},
+		Profiles: map[string]config.Profile{"main": {Model: "capped-model"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// Oversized body (2000 bytes > 1024 cap).
+	big := `{"model":"capped-model","max_tokens":50,"messages":[{"role":"user","content":"` + strings.Repeat("x", 2000) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages", testToken, big)
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+	for _, want := range []string{"invalid_request_error", "too large", "max_request_bytes"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q: %s", want, body)
+		}
+	}
+	if reached {
+		t.Error("oversized body must not reach upstream")
+	}
+
+	// Small body passes.
+	reached = false
+	resp, body = post(t, ts.URL+"/v1/messages", testToken,
+		`{"model":"capped-model","max_tokens":50,"messages":[{"role":"user","content":"hi"}]}`)
+	if resp.StatusCode != 200 {
+		t.Fatalf("small body status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if !reached {
+		t.Error("small body should reach upstream")
+	}
+}
+
+// TestAutoRouteByteCapExcludesTier: a routing rule where the light tier's
+// provider has a byte cap; an oversized body routes away from it.
+func TestAutoRouteByteCapExcludesTier(t *testing.T) {
+	var seenModels []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Model string `json:"model"`
+		}
+		json.Unmarshal(body, &req)
+		seenModels = append(seenModels, req.Model)
+		w.Header().Set("Content-Type", "application/json")
+		if req.Model == "classifier-up" {
+			io.WriteString(w, `{"id":"c","choices":[{"index":0,"message":{"role":"assistant","content":"light"},"finish_reason":"stop"}],"usage":{"prompt_tokens":50,"completion_tokens":1}}`)
+			return
+		}
+		io.WriteString(w, `{"id":"m","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"fake":   {Type: config.ProviderOpenAI, BaseURL: upstream.URL},
+			"capped": {Type: config.ProviderOpenAI, BaseURL: upstream.URL, MaxRequestBytes: 512},
+		},
+		Models: map[string]config.Model{
+			"cheap": {Provider: "fake", ID: "classifier-up"},
+			"big":   {Provider: "fake", ID: "deep-up", ContextWindow: 128000},
+			"small": {Provider: "capped", ID: "light-up", ContextWindow: 128000},
+		},
+		Routing: map[string]config.RouteRule{
+			"auto": {Classifier: "cheap", Default: "deep",
+				Tiers: map[string]string{"deep": "big", "light": "small"}},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// Body > 512 bytes exceeds small's provider cap; classifier says light, but
+	// the byte cap filters it out → routes to big (deep).
+	big := `{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + strings.Repeat("word ", 200) + `"}]}`
+	resp, body := post(t, ts.URL+"/v1/messages", testToken, big)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+	if len(seenModels) < 2 || seenModels[len(seenModels)-1] != "deep-up" {
+		t.Errorf("routed to %v, want last call to deep-up (escaped byte-capped light)", seenModels)
+	}
+	alias, tier, model, reason, ok, err := st.LatestRouteDecision("sess-test")
+	if err != nil || !ok || tier != "deep" || model != "big" {
+		t.Errorf("decision: alias=%s tier=%s model=%s ok=%v err=%v, want tier=deep model=big", alias, tier, model, ok, err)
+	}
+	// With only "deep" eligible (light byte-filtered), the classifier call is
+	// skipped and there's no remap to record — reason stays empty. The point
+	// is that the request escaped the byte-capped tier, which it did (tier=deep).
+	_ = reason
+}

--- a/internal/router/size_test.go
+++ b/internal/router/size_test.go
@@ -1,0 +1,171 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/config"
+)
+
+func sizedCfg() *config.Config {
+	mk := func(id string, budget, maxOut int) config.Model {
+		m := config.Model{Provider: "fake", ID: id}
+		m.ContextWindow = budget
+		m.MaxOutput = maxOut
+		return m
+	}
+	return &config.Config{
+		Providers: map[string]config.Provider{
+			"fake": {Type: config.ProviderOpenAI, BaseURL: "http://x"},
+		},
+		Models: map[string]config.Model{
+			"opus":    mk("opus-up", 128000, 0),
+			"sonnet":  mk("sonnet-up", 32000, 0),
+			"qwen":    mk("qwen-up", 8000, 0),
+			"tiny":    mk("tiny-up", 1000, 0),
+			"unknown": {Provider: "fake", ID: "unknown-up"}, // no context_window
+		},
+	}
+}
+
+func reqWith(text string) *anthropic.MessagesRequest {
+	return &anthropic.MessagesRequest{
+		MaxTokens: 100,
+		Messages:  []anthropic.Message{{Role: "user", Content: anthropic.MessageBody{{Type: "text", Text: text}}}},
+	}
+}
+
+func TestReservedOutput(t *testing.T) {
+	cases := []struct{ req, cap, want int }{
+		{0, 0, defaultReservedOutput}, // nothing set
+		{100, 0, 100},                 // request max_tokens wins
+		{50000, 8000, 8000},           // capped by model MaxOutput
+		{4000, 8000, 4000},            // request below cap, used as-is
+		{0, 8000, 8000},               // no request, use cap
+	}
+	for _, c := range cases {
+		if got := reservedOutput(c.req, c.cap); got != c.want {
+			t.Errorf("reservedOutput(%d,%d)=%d want %d", c.req, c.cap, got, c.want)
+		}
+	}
+}
+
+func TestClassifyTierFitNoBudgetsShortCircuits(t *testing.T) {
+	// No tiers have a known budget → Required==0, all eligible, no estimate.
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{"fake": {Type: config.ProviderOpenAI, BaseURL: "http://x"}},
+		Models: map[string]config.Model{
+			"opus":   {Provider: "fake", ID: "opus-up"},
+			"sonnet": {Provider: "fake", ID: "sonnet-up"},
+		},
+	}
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet"}}
+	fit := classifyTierFit(cfg, rule, reqWith("hello"))
+	if fit.Required != 0 || fit.EstInput != 0 {
+		t.Errorf("expected short-circuit, got Required=%d EstInput=%d", fit.Required, fit.EstInput)
+	}
+	if !fit.Eligible["deep"] || !fit.Eligible["standard"] {
+		t.Errorf("all tiers should be eligible, got %v", fit.Eligible)
+	}
+}
+
+func TestClassifyTierFitFilters(t *testing.T) {
+	cfg := sizedCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"}}
+	// ~30000 tokens (60000 chars / 3.5 → ~17143, +10% margin ~18857, +reserved) → exceeds qwen's 8K, fits sonnet's 32K and opus's 128K.
+	fit := classifyTierFit(cfg, rule, reqWith(repeat("w ", 30000)))
+	if fit.Required == 0 {
+		t.Fatal("expected an estimate")
+	}
+	if fit.Eligible["light"] {
+		t.Error("qwen (8K) should be filtered out")
+	}
+	if !fit.Eligible["standard"] || !fit.Eligible["deep"] {
+		t.Error("sonnet and opus should remain eligible")
+	}
+	if len(fit.Filtered) != 1 || fit.Filtered[0] != "light" {
+		t.Errorf("Filtered=%v want [light]", fit.Filtered)
+	}
+}
+
+func TestRemapTierSmallestFitting(t *testing.T) {
+	cfg := sizedCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"}}
+	// qwen excluded; remap from light → sonnet (smallest that fits), not opus.
+	fit := fitDecision{
+		Eligible: map[string]bool{"deep": true, "standard": true, "light": false},
+		Required: 10000,
+	}
+	if got := remapTier(cfg, rule, fit, "light"); got != "standard" {
+		t.Errorf("remap light = %s, want standard (smallest fitting)", got)
+	}
+}
+
+func TestRemapTierAlreadyEligible(t *testing.T) {
+	cfg := sizedCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet"}}
+	fit := fitDecision{Eligible: map[string]bool{"deep": true, "standard": true}, Required: 100}
+	if got := remapTier(cfg, rule, fit, "deep"); got != "deep" {
+		t.Errorf("eligible tier must pass through, got %s", got)
+	}
+}
+
+func TestRemapTierNothingFitsFallsBackToLargest(t *testing.T) {
+	cfg := sizedCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"}}
+	// Nothing fits: all eligible=false. remap returns the largest known budget (opus).
+	fit := fitDecision{
+		Eligible: map[string]bool{"deep": false, "standard": false, "light": false},
+		Required: 999999,
+	}
+	if got := remapTier(cfg, rule, fit, "light"); got != "deep" {
+		t.Errorf("nothing fits: remap = %s, want deep (largest budget)", got)
+	}
+}
+
+func TestRemapTierPrefersUnknownBudgetWhenNothingKnownFits(t *testing.T) {
+	cfg := sizedCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "unknown", "light": "qwen"}}
+	// qwen (8K) doesn't fit; deep is unknown-budget (infinite). Prefer deep.
+	fit := fitDecision{
+		Eligible: map[string]bool{"deep": true, "light": false},
+		Required: 999999,
+	}
+	if got := remapTier(cfg, rule, fit, "light"); got != "deep" {
+		t.Errorf("should prefer unknown-budget tier, got %s", got)
+	}
+}
+
+func TestPromptTooLong(t *testing.T) {
+	cfg := sizedCfg()
+	route, _ := cfg.Resolve("tiny") // 1000 budget
+
+	// Small request fits.
+	if overflow, _, _ := promptTooLong(route, reqWith("hi")); overflow {
+		t.Error("small request should not overflow")
+	}
+	// Large request overflows.
+	overflow, required, budget := promptTooLong(route, reqWith(repeat("w ", 10000)))
+	if !overflow {
+		t.Errorf("large request should overflow, required=%d budget=%d", required, budget)
+	}
+	if budget != 1000 {
+		t.Errorf("budget=%d want 1000", budget)
+	}
+}
+
+func TestPromptTooLongUnknownBudgetNoGuard(t *testing.T) {
+	cfg := sizedCfg()
+	route, _ := cfg.Resolve("unknown") // no context_window
+	if overflow, _, _ := promptTooLong(route, reqWith(repeat("w ", 100000))); overflow {
+		t.Error("unknown budget must never trip the guard")
+	}
+}
+
+func repeat(s string, n int) string {
+	out := ""
+	for i := 0; i < n; i++ {
+		out += s
+	}
+	return out
+}

--- a/internal/router/size_test.go
+++ b/internal/router/size_test.go
@@ -60,7 +60,7 @@ func TestClassifyTierFitNoBudgetsShortCircuits(t *testing.T) {
 		},
 	}
 	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet"}}
-	fit := classifyTierFit(cfg, rule, reqWith("hello"))
+	fit := classifyTierFit(cfg, rule, reqWith("hello"), 0)
 	if fit.Required != 0 || fit.EstInput != 0 {
 		t.Errorf("expected short-circuit, got Required=%d EstInput=%d", fit.Required, fit.EstInput)
 	}
@@ -73,7 +73,7 @@ func TestClassifyTierFitFilters(t *testing.T) {
 	cfg := sizedCfg()
 	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"}}
 	// ~30000 tokens (60000 chars / 3.5 → ~17143, +10% margin ~18857, +reserved) → exceeds qwen's 8K, fits sonnet's 32K and opus's 128K.
-	fit := classifyTierFit(cfg, rule, reqWith(repeat("w ", 30000)))
+	fit := classifyTierFit(cfg, rule, reqWith(repeat("w ", 30000)), 0)
 	if fit.Required == 0 {
 		t.Fatal("expected an estimate")
 	}
@@ -168,4 +168,73 @@ func repeat(s string, n int) string {
 		out += s
 	}
 	return out
+}
+
+// --- byte-size guard ---
+
+func byteCfg() *config.Config {
+	return &config.Config{
+		Providers: map[string]config.Provider{
+			// "fake" has no byte cap; "capped" caps bodies at 1024 bytes.
+			"fake":   {Type: config.ProviderOpenAI, BaseURL: "http://x"},
+			"capped": {Type: config.ProviderOpenAI, BaseURL: "http://x", MaxRequestBytes: 1024},
+		},
+		Models: map[string]config.Model{
+			"big":   {Provider: "fake", ID: "big-up", ContextWindow: 128000},
+			"small": {Provider: "capped", ID: "small-up", ContextWindow: 128000},
+		},
+	}
+}
+
+func TestBodyTooLarge(t *testing.T) {
+	cfg := byteCfg()
+	route, _ := cfg.Resolve("small") // capped provider, 1024-byte cap
+	if tooLarge, _, _ := bodyTooLarge(route, 500); tooLarge {
+		t.Error("500 bytes should fit under 1024 cap")
+	}
+	if tooLarge, size, cap := bodyTooLarge(route, 2000); !tooLarge {
+		t.Errorf("2000 bytes should overflow 1024 cap (size=%d cap=%d)", size, cap)
+	}
+	if cap := route.Provider.MaxRequestBytes; cap != 1024 {
+		t.Errorf("cap=%d want 1024", cap)
+	}
+}
+
+func TestBodyTooLargeUnknownCapNoGuard(t *testing.T) {
+	cfg := byteCfg()
+	route, _ := cfg.Resolve("big") // uncapped provider
+	if tooLarge, _, _ := bodyTooLarge(route, 10_000_000); tooLarge {
+		t.Error("unknown cap must never trip the guard")
+	}
+}
+
+func TestClassifyTierFitFiltersByBytes(t *testing.T) {
+	cfg := byteCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "big", "light": "small"}}
+	// Body of 2000 bytes exceeds small's 1024-byte cap but fits big. Both
+	// tiers have the same 128K token budget, so only the byte cap differentiates.
+	fit := classifyTierFit(cfg, rule, reqWith("hi"), 2000)
+	if fit.Eligible["light"] {
+		t.Error("small (1024-byte cap) should be filtered out by a 2000-byte body")
+	}
+	if !fit.Eligible["deep"] {
+		t.Error("big (uncapped) should remain eligible")
+	}
+	if len(fit.Filtered) != 1 || fit.Filtered[0] != "light" {
+		t.Errorf("Filtered=%v want [light]", fit.Filtered)
+	}
+}
+
+func TestRemapTierEscapesByteCap(t *testing.T) {
+	cfg := byteCfg()
+	rule := config.RouteRule{Tiers: map[string]string{"deep": "big", "light": "small"}}
+	// Classifier picked light, but its 1024-byte cap is exceeded → remap to big.
+	fit := fitDecision{
+		Eligible:  map[string]bool{"deep": true, "light": false},
+		Required:  100,
+		BodyBytes: 2000,
+	}
+	if got := remapTier(cfg, rule, fit, "light"); got != "deep" {
+		t.Errorf("byte overflow remap = %s, want deep", got)
+	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -98,6 +98,7 @@ CREATE INDEX IF NOT EXISTS idx_usage_session ON usage_events(session_id);
 	for _, col := range []string{
 		"ALTER TABLE usage_events ADD COLUMN ctx_budget INTEGER DEFAULT 0",
 		"ALTER TABLE usage_events ADD COLUMN reported_input INTEGER DEFAULT 0",
+		"ALTER TABLE route_decisions ADD COLUMN reason TEXT DEFAULT ''",
 	} {
 		if _, err := s.db.Exec(col); err != nil && !strings.Contains(err.Error(), "duplicate column") {
 			return err
@@ -189,24 +190,26 @@ FROM sessions WHERE ended_at IS NULL ORDER BY started_at DESC`)
 
 // RecordRouteDecision persists the auto-router's tier/model choice for a
 // session's current turn, overwriting any prior decision for that session
-// (a session re-classifies as new user turns arrive).
-func (s *Store) RecordRouteDecision(sessionID, alias, tier, model string, at time.Time) error {
+// (a session re-classifies as new user turns arrive). reason is a free-text
+// note — e.g. "size:light→standard" when size-aware routing remapped a tier
+// — empty for a plain classifier decision.
+func (s *Store) RecordRouteDecision(sessionID, alias, tier, model, reason string, at time.Time) error {
 	_, err := s.db.Exec(`INSERT OR REPLACE INTO route_decisions
-(session_id, alias, tier, model, at) VALUES (?,?,?,?,?)`,
-		sessionID, alias, tier, model, at.Unix())
+(session_id, alias, tier, model, reason, at) VALUES (?,?,?,?,?,?)`,
+		sessionID, alias, tier, model, reason, at.Unix())
 	return err
 }
 
 // LatestRouteDecision returns the most recent auto-router decision recorded
 // for a session, if any. ok is false when no decision has been recorded yet
 // (e.g. the profile isn't using a routing alias).
-func (s *Store) LatestRouteDecision(sessionID string) (alias, tier, model string, ok bool, err error) {
-	row := s.db.QueryRow(`SELECT alias, tier, model FROM route_decisions WHERE session_id = ?`, sessionID)
-	err = row.Scan(&alias, &tier, &model)
+func (s *Store) LatestRouteDecision(sessionID string) (alias, tier, model, reason string, ok bool, err error) {
+	row := s.db.QueryRow(`SELECT alias, tier, model, reason FROM route_decisions WHERE session_id = ?`, sessionID)
+	err = row.Scan(&alias, &tier, &model, &reason)
 	if err == sql.ErrNoRows {
-		return "", "", "", false, nil
+		return "", "", "", "", false, nil
 	}
-	return alias, tier, model, err == nil, err
+	return alias, tier, model, reason, err == nil, err
 }
 
 // RecordGoalDecision persists the auto-goal classifier's verdict for a

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -14,31 +14,31 @@ func TestRouteDecisionRoundTrip(t *testing.T) {
 	defer st.Close()
 
 	// No decision recorded yet.
-	if _, _, _, ok, err := st.LatestRouteDecision("sess-1"); ok || err != nil {
+	if _, _, _, _, ok, err := st.LatestRouteDecision("sess-1"); ok || err != nil {
 		t.Errorf("empty lookup: ok=%v err=%v, want ok=false err=nil", ok, err)
 	}
 
-	if err := st.RecordRouteDecision("sess-1", "auto", "deep", "opus", time.Now()); err != nil {
+	if err := st.RecordRouteDecision("sess-1", "auto", "deep", "opus", "size:light→deep", time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	alias, tier, model, ok, err := st.LatestRouteDecision("sess-1")
-	if err != nil || !ok || alias != "auto" || tier != "deep" || model != "opus" {
-		t.Errorf("got alias=%s tier=%s model=%s ok=%v err=%v, want auto/deep/opus/true/nil",
-			alias, tier, model, ok, err)
+	alias, tier, model, reason, ok, err := st.LatestRouteDecision("sess-1")
+	if err != nil || !ok || alias != "auto" || tier != "deep" || model != "opus" || reason != "size:light→deep" {
+		t.Errorf("got alias=%s tier=%s model=%s reason=%q ok=%v err=%v, want auto/deep/opus/\"size:light→deep\"/true/nil",
+			alias, tier, model, reason, ok, err)
 	}
 
 	// A later decision for the same session overwrites, not duplicates.
-	if err := st.RecordRouteDecision("sess-1", "auto", "light", "qwen", time.Now()); err != nil {
+	if err := st.RecordRouteDecision("sess-1", "auto", "light", "qwen", "", time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	alias, tier, model, ok, err = st.LatestRouteDecision("sess-1")
-	if err != nil || !ok || alias != "auto" || tier != "light" || model != "qwen" {
-		t.Errorf("after overwrite: alias=%s tier=%s model=%s ok=%v err=%v, want auto/light/qwen/true/nil",
-			alias, tier, model, ok, err)
+	alias, tier, model, reason, ok, err = st.LatestRouteDecision("sess-1")
+	if err != nil || !ok || alias != "auto" || tier != "light" || model != "qwen" || reason != "" {
+		t.Errorf("after overwrite: alias=%s tier=%s model=%s reason=%q ok=%v err=%v, want auto/light/qwen/\"\"/true/nil",
+			alias, tier, model, reason, ok, err)
 	}
 
 	// A different session is unaffected.
-	if _, _, _, ok, err := st.LatestRouteDecision("sess-2"); ok || err != nil {
+	if _, _, _, _, ok, err := st.LatestRouteDecision("sess-2"); ok || err != nil {
 		t.Errorf("other session: ok=%v err=%v, want ok=false err=nil", ok, err)
 	}
 }


### PR DESCRIPTION
## Problem

Phases 1–2 (v0.1.7) gave models a declared context budget and made Claude Code's auto-compact fire at the right relative fullness. Two gaps remained:

1. **Auto-routing ignored size.** The classifier picked a tier purely from the user's text — a 150K-token conversation could be routed "light" onto a 32K model and overflow.
2. **No dispatch guard.** An oversized request reached upstream and failed with a mangled, provider-specific 400 instead of a clean, Anthropic-shaped error.

## Changes

**Size-aware tier selection** (`internal/router/size.go` + `autoroute.go`): before classifying, the router estimates the request's input size and filters out tiers whose budget can't hold input + reserved output headroom. The classifier runs over the survivors; if its pick was filtered out, it's remapped upward to the smallest tier that still fits. A mid-turn continuation that outgrew its sticky tier is remapped and pinned the same way (no re-classify). When only one tier fits, the classifier call is skipped entirely. Tiers with no declared `context_window` are treated as infinite (always eligible) — all-anthropic and legacy configs are unaffected (`Required==0` fast path).

**Dispatch guard** (`server.go`): a pre-dispatch check catches the hard-overflow case for models with a known budget — requests the budget can't hold are refused with `400 invalid_request_error` ("request too large for model context budget") before reaching upstream. `400` (not `413`) so Claude Code doesn't retry-spin, matching the budget-gate rationale. Skipped for `count_tokens` and unknown budgets.

**Observability**: `autoroute_size` Debug log (estimate/required/excluded/remap); new `route_decisions.reason` column (`size:light→standard`, `size:sticky:light→standard`) surfaced in the statusline and `agentic context`.

## Tests

- Unit (`size_test.go`): `reservedOutput`, `classifyTierFit` (incl. no-budget short-circuit + filtering), `remapTier` (smallest-fitting / already-eligible / nothing-fits→largest / prefer-unknown-when-nothing-known-fits), `promptTooLong` (incl. unknown-budget no-op).
- Autoroute (`autoroute_test.go`): remap-up-from-light, picks-smallest, only-eligible-skips-classifier, sticky-but-too-big-remaps, unknown-budget-eligible, no-budgets-no-filtering. Original 3 tests stay green.
- E2e (`size_e2e_test.go`): guard fires (400 + body shape) and small request passes; guard skips unknown budget; count_tokens skips guard; auto-route remap end-to-end with `reason` recorded.
- Store: `route_decisions.reason` round-trip.

## Live verification

Isolated sandbox router (separate HOME/port, branch binary; production leader untouched) → glm-52 upstream:
- **Guard**: a `claude -p` session grew past the 20K declared budget; the next request returned the clean `400 "request too large for model context budget"` (router log `prompt_too_long estimated_input=109454 budget=20000`) instead of a mangled upstream error. Earlier turns in the session succeeded.
- **Routing**: oversized-to-8K requests routed to the 30K tier (router log `ctx_budget=30000`), never the 8K light tier.
- Hot-reload applied the routing config mid-test; the older `claude-sonnet-5` direct config also worked.

## Notes / follow-ups

- `defaultReservedOutput = 8192` is a named constant in `size.go` — easy to tune or promote to config.
- The `autoroute_size` Debug log isn't visible at the default Info level; a `--verbose`/debug-level flag would surface it (deferred).
- Bundles cleanly with the already-landed `agentic update` restart report for a v0.1.8 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)