### PR TITLE
statusline: fix budget suffix attaching to the goal segment

### DIFF
--- a/cmd/statusline.go
+++ b/cmd/statusline.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/maorbril/agentic/internal/config"
 	"github.com/maorbril/agentic/internal/store"
 )
 
@@ -61,31 +62,46 @@ var statuslineCmd = &cobra.Command{
 			}
 		}
 
-		line := fmt.Sprintf("%s · %s · sess $%.2f · day $%.2f",
-			orDefault(profile, "agentic"), modelPart, sess, day)
-
-		if goal, reason, ok, _ := st.LatestGoalDecision(sessionID); ok && goal {
-			line += fmt.Sprintf(" · \033[33m⟳ goal\033[0m (%s)", truncateForStatus(reason))
+		var goalReason string
+		goal, reason, ok, _ := st.LatestGoalDecision(sessionID)
+		if ok && goal {
+			goalReason = reason
 		}
 
-		if cfg.Budgets != nil && cfg.Budgets.Daily > 0 {
-			frac := day / cfg.Budgets.Daily
-			color := "\033[32m" // green
-			warnAt := cfg.Budgets.WarnAt
-			if warnAt == 0 {
-				warnAt = 0.8
-			}
-			switch {
-			case frac >= 1:
-				color = "\033[31m" // red
-			case frac >= warnAt:
-				color = "\033[33m" // yellow
-			}
-			line += fmt.Sprintf("/$%.0f %s[%s]\033[0m", cfg.Budgets.Daily, color, bar(frac, 6))
-		}
-		fmt.Println(line)
+		fmt.Println(statusLine(orDefault(profile, "agentic"), modelPart, sess, day, cfg.Budgets, goalReason))
 		return nil
 	},
+}
+
+// statusLine builds the printed status line. Segment order matters: the
+// budget suffix ("/$600 [bar]") describes the day-spend figure and must sit
+// immediately after it — appending it after the goal segment instead makes
+// it read as though it belongs to the goal reason. goalReason == "" omits
+// the goal segment entirely.
+func statusLine(profile, modelPart string, sess, day float64, budgets *config.Budget, goalReason string) string {
+	line := fmt.Sprintf("%s · %s · sess $%.2f · day $%.2f", profile, modelPart, sess, day)
+
+	if budgets != nil && budgets.Daily > 0 {
+		frac := day / budgets.Daily
+		color := "\033[32m" // green
+		warnAt := budgets.WarnAt
+		if warnAt == 0 {
+			warnAt = 0.8
+		}
+		switch {
+		case frac >= 1:
+			color = "\033[31m" // red
+		case frac >= warnAt:
+			color = "\033[33m" // yellow
+		}
+		line += fmt.Sprintf("/$%.0f %s[%s]\033[0m", budgets.Daily, color, bar(frac, 6))
+	}
+
+	if goalReason != "" {
+		line += fmt.Sprintf(" · \033[33m⟳ goal\033[0m (%s)", truncateForStatus(goalReason))
+	}
+
+	return line
 }
 
 func orDefault(s, def string) string {

--- a/cmd/statusline_test.go
+++ b/cmd/statusline_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maorbril/agentic/internal/config"
+)
+
+// TestStatusLineBudgetSuffixAttachesToDaySpend guards against a regression
+// where the budget suffix ("/$600 [bar]") was appended after the goal
+// segment instead of right after the day-spend figure it describes, making
+// it visually read as part of the goal reason (see screenshot in the PR).
+func TestStatusLineBudgetSuffixAttachesToDaySpend(t *testing.T) {
+	budgets := &config.Budget{Daily: 600}
+	line := statusLine("main", "auto→opus (deep)", 91.68, 328.95, budgets, "Monitor task completion, wait for CI")
+
+	dayFigure := "day $328.95"
+	budgetSuffix := "/$600"
+	goalSegment := "⟳ goal"
+
+	dayIdx := strings.Index(line, dayFigure)
+	suffixIdx := strings.Index(line, budgetSuffix)
+	goalIdx := strings.Index(line, goalSegment)
+
+	if dayIdx == -1 || suffixIdx == -1 || goalIdx == -1 {
+		t.Fatalf("line missing an expected segment: %q", line)
+	}
+	// The budget suffix must immediately follow the day figure (only the
+	// closing color-reset/bracket bytes of the day segment between them),
+	// and the goal segment must come strictly after the budget suffix.
+	if suffixIdx < dayIdx {
+		t.Errorf("budget suffix must come after the day figure: %q", line)
+	}
+	if goalIdx < suffixIdx {
+		t.Errorf("goal segment must come after the budget suffix, not before it: %q", line)
+	}
+	// Nothing (in particular no " · " separator) sits between "day $328.95"
+	// and "/$600" — that's what makes the suffix read as attached to day
+	// spend rather than floating after an unrelated segment.
+	between := line[dayIdx+len(dayFigure) : suffixIdx]
+	if strings.Contains(between, "·") {
+		t.Errorf("a segment separator sits between day spend and its budget suffix: %q", line)
+	}
+}
+
+func TestStatusLineNoGoalOmitsSegment(t *testing.T) {
+	line := statusLine("main", "sonnet", 1, 2, nil, "")
+	if strings.Contains(line, "goal") {
+		t.Errorf("no goal reason should mean no goal segment: %q", line)
+	}
+}
+
+func TestStatusLineNoBudgetOmitsSuffix(t *testing.T) {
+	line := statusLine("main", "sonnet", 1, 2, nil, "")
+	if strings.Contains(line, "/$") {
+		t.Errorf("no budget configured should mean no suffix: %q", line)
+	}
+}


### PR DESCRIPTION
## Bug

Reported with a screenshot showing:

```
main · auto→opus (deep) · sess $91.68 · day $328.95 · ⟳ goal (Monitor task completion,…)/$600 [bar]
```

The `/$600 [bar]` budget suffix visually reads as part of the goal segment. It's actually meant to describe the `day $328.95` figure — it's the fraction of the daily budget spent so far — but the code appended it *after* the goal segment instead of right after the day figure.

## Fix

Reordered so the budget suffix is appended immediately after `day $X.XX`, with the goal segment trailing:

```
main · auto→opus (deep) · sess $91.68 · day $328.95/$600 [███░░░] · ⟳ goal (Monitor task completion,…)
```

## Verification

- Extracted the line-building logic into a pure `statusLine()` function (`cmd/statusline.go`) so it's testable without a database — the `cmd` package had zero tests before this.
- Added `cmd/statusline_test.go`: `TestStatusLineBudgetSuffixAttachesToDaySpend` asserts the budget suffix immediately follows the day figure and the goal segment comes strictly after it. **Verified the test fails against the old ordering** (reintroduced the bug locally, confirmed the test catches it byte-for-byte against the reported output, then restored the fix) — so this is a real regression guard, not just a happy-path check.
- Also seeded a sandbox store with data matching the screenshot (sess $91.68, day $328.95/$600, tier=deep→opus, goal="Monitor task completion...") and ran the actual `agentic statusline` binary end-to-end to visually confirm the corrected rendering.
- Full suite green (`go build`, `go vet`, `go test ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)