### PR TITLE
Generate subagent definitions for configured model aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ Two things you should understand before routing through agentic:
 - **Billing.** Traffic through the router is billed to **API keys**, not your Claude Pro/Max subscription. OAuth credentials are never proxied. For subscription billing, use a `passthrough: true` profile — normal claude, no tracking.
 - **Fidelity.** Non-Anthropic models work through translation, but Claude Code's prompts and tool patterns are tuned for Claude, so expect them to be clunkier in the main loop. They shine as cheap workhorses for background tasks and subagents. Specific gaps: no prompt caching on OpenAI-dialect backends (provider-side implicit caching still shows up as cache reads), thinking blocks are display-only, Anthropic server tools (web search, code execution) are unavailable on translated models, `top_k` is dropped, stop sequences truncate to four, and token counting for translated models is a deliberate ~15% overestimate so auto-compact fires early instead of overflowing context. Set `max_output` on models whose output cap is below what Claude Code requests (it asks for 32K), and `context_window` on models whose window differs from the ~200K Claude Code assumes (see [Context scaling](#context-scaling)).
 
+## Subagents on any model
+
+Claude Code's built-in Agent tool takes a fixed `model` parameter (`sonnet | opus | haiku | fable`), so a routed alias like `qwen` can't be picked through it — subagents are stuck on the Claude tiers even when your best tool for the job is something else. A subagent *definition's* `model:` frontmatter has no such limit, and behind agentic's local endpoint Claude Code passes that string straight through, so agentic generates one subagent per configured model alias:
+
+```bash
+agentic agents sync     # writes ~/.claude/agents/agentic-<alias>.md, one per model alias
+agentic agents list     # what's implied by your config, and what's pending
+```
+
+Every model you've configured becomes selectable by name — `subagent_type: "agentic-qwen"`, `"agentic-grok"`, `"agentic-gpt-5-6-sol"` — and its traffic routes, prices, and budgets like any other agentic request. The set is derived from your own `models:` map, so it's whatever *you* configured; nothing is hardcoded.
+
+When your aliases change, the next `agentic` launch offers to refresh them (once — decline and it stays quiet until the aliases change again; `AGENTIC_NO_AGENT_SYNC=1` opts out entirely). Only files prefixed `agentic-` are ever written or removed, so your own subagents are never touched.
+
 ## Works with clauder
 
 If [clauder](https://github.com/MaorBril/clauder) is installed, agentic launches sessions through `clauder wrap --slave`, so your instances get persistent memory, can message each other, and run with clauder's auto-approved tool set for autonomous operation. Launch with `--no-clauder` for a bare claude session. The two tools are independent; each works without the other.
@@ -166,6 +179,7 @@ If [clauder](https://github.com/MaorBril/clauder) is installed, agentic launches
 | `agentic setup` | first-run config, token, statusline registration |
 | `agentic cost [--week\|--month] [--by model\|profile\|session]` | spend report |
 | `agentic context [session-id]` | context-fullness trajectory (true vs reported tokens) |
+| `agentic agents list/sync` | subagent definitions for your model aliases |
 | `agentic models add/list/remove/test/update-prices` | model aliases |
 | `agentic providers add/list/remove` | upstream providers |
 | `agentic profiles list/show` · `agentic budget set` | profiles and caps |

--- a/cmd/agentscmd.go
+++ b/cmd/agentscmd.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/maorbril/agentic/internal/agents"
+)
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "Claude Code subagents for your model aliases",
+	Long: `Claude Code's built-in Agent tool only accepts a fixed model parameter
+(sonnet | opus | haiku | fable), so a routed alias like "qwen" can't be
+selected through it. A subagent definition's model frontmatter has no such
+limit, so agentic generates one subagent per configured model alias —
+making every model selectable by name (subagent_type: "agentic-qwen").
+
+Definitions live in ~/.claude/agents/agentic-<alias>.md. Only files with the
+"agentic-" prefix are ever written or removed; your own agents are untouched.`,
+}
+
+var agentsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show the subagents implied by your model aliases, and their state on disk",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		dir, err := agents.Dir()
+		if err != nil {
+			return err
+		}
+		want := agents.Desired(cfg)
+		if len(want) == 0 {
+			fmt.Println("no model aliases configured — add one with `agentic models add`")
+			return nil
+		}
+		changes, err := agents.Diff(cfg, dir)
+		if err != nil {
+			return err
+		}
+		pending := map[string]string{}
+		for _, c := range changes {
+			pending[c.Name] = c.Kind
+		}
+
+		tw := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+		fmt.Fprintln(tw, "SUBAGENT\tALIAS\tSTATE")
+		for _, d := range want {
+			state := "in sync"
+			if k, ok := pending[d.Name]; ok {
+				state = k + " pending"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", d.Name, d.Alias, state)
+		}
+		for _, c := range changes {
+			if c.Kind == "remove" {
+				fmt.Fprintf(tw, "%s\t(alias gone)\tremove pending\n", c.Name)
+			}
+		}
+		tw.Flush()
+		fmt.Printf("\n%s\n", dir)
+		if len(changes) > 0 {
+			fmt.Println("run `agentic agents sync` to apply")
+		}
+		return nil
+	},
+}
+
+var agentsSyncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Write subagent definitions for your model aliases",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, dataDir, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		dir, err := agents.Dir()
+		if err != nil {
+			return err
+		}
+		changes, err := agents.Sync(cfg, dir)
+		if err != nil {
+			return err
+		}
+		if len(changes) == 0 {
+			fmt.Println("✓ subagents already in sync with your model aliases")
+			return nil
+		}
+		for _, c := range changes {
+			fmt.Printf("  %-8s %s\n", c.Kind, c.Name)
+		}
+		fmt.Printf("✓ synced %d subagent(s) in %s\n", len(changes), dir)
+		fmt.Println("  restart Claude Code sessions to pick them up")
+		agents.ClearDeclined(dataDir)
+		return nil
+	},
+}
+
+func init() {
+	agentsCmd.AddCommand(agentsListCmd, agentsSyncCmd)
+	rootCmd.AddCommand(agentsCmd)
+}

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -1,0 +1,273 @@
+// Package agents generates Claude Code subagent definitions for the model
+// aliases in the user's config.
+//
+// Why this exists: Claude Code's built-in Agent tool takes a fixed
+// model parameter (sonnet | opus | haiku | fable), so a routed alias like
+// "qwen" can never be selected through it. A subagent *definition's* model
+// frontmatter has no such restriction — and behind a custom
+// ANTHROPIC_BASE_URL (which agentic always sets) Claude Code passes the
+// string through unvalidated — so one generated definition per alias makes
+// every configured model selectable by name (subagent_type:
+// "agentic-qwen").
+//
+// The alias list comes from the user's own config, so the generated set is
+// whatever that install has configured — nothing is hardcoded.
+package agents
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/maorbril/agentic/internal/config"
+)
+
+// Prefix marks the files this package owns. Anything without it in
+// ~/.claude/agents is a user's own agent and is never read, written, or
+// deleted.
+const Prefix = "agentic-"
+
+// Definition is one generated subagent file.
+type Definition struct {
+	Alias    string // model alias from config
+	Name     string // subagent name (Prefix + slug)
+	Filename string // Name + ".md"
+	Body     string // full file contents
+}
+
+// Desired returns the definitions implied by cfg, sorted by name. Routing
+// rules (e.g. "auto") are excluded: they are classifier rules rather than
+// concrete models, and a subagent that silently re-tiers itself would make
+// the chosen model unpredictable.
+func Desired(cfg *config.Config) []Definition {
+	if cfg == nil {
+		return nil
+	}
+	out := make([]Definition, 0, len(cfg.Models))
+	for alias := range cfg.Models {
+		out = append(out, definitionFor(cfg, alias))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func definitionFor(cfg *config.Config, alias string) Definition {
+	name := Prefix + slug(alias)
+	m := cfg.Models[alias]
+
+	// Describe the model concretely so the orchestrating model can tell the
+	// generated agents apart when choosing one.
+	var facts []string
+	if m.ID != "" {
+		facts = append(facts, "upstream model "+m.ID)
+	}
+	if m.Provider != "" {
+		facts = append(facts, "provider "+m.Provider)
+	}
+	if b := m.ContextBudget(); b > 0 {
+		facts = append(facts, fmt.Sprintf("%s context budget", humanTokens(int64(b))))
+	}
+	detail := ""
+	if len(facts) > 0 {
+		detail = " (" + strings.Join(facts, ", ") + ")"
+	}
+
+	body := fmt.Sprintf(`---
+name: %s
+description: Runs the task on the %q model alias%s, routed through agentic. Use when you specifically want this model — for cost, context size, or capability reasons — rather than the default sonnet/opus/haiku tiers.
+model: %s
+---
+
+You are running on the %q model alias, routed through the local agentic
+router to %s.
+
+Complete the task you were given and report the result. Your final message
+is the return value the caller receives, so make it the answer itself — not
+a description of what you did.
+`, name, alias, detail, alias, alias, orUnknown(m.ID))
+
+	return Definition{Alias: alias, Name: name, Filename: name + ".md", Body: body}
+}
+
+// slug makes an alias safe for a subagent name / filename. Claude Code
+// subagent names are referenced verbatim, so keep them to a conservative
+// character set.
+func slug(alias string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(alias) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			// Collapse runs of separators (".", "_", " ", "/") to one dash.
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "its configured upstream model"
+	}
+	return s
+}
+
+func humanTokens(n int64) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1e6)
+	case n >= 1_000:
+		return fmt.Sprintf("%dK", n/1_000)
+	default:
+		return fmt.Sprint(n)
+	}
+}
+
+// Dir returns ~/.claude/agents.
+func Dir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "agents"), nil
+}
+
+// Change is one pending difference between config and disk.
+type Change struct {
+	Name string
+	Kind string // "create" | "update" | "remove"
+}
+
+// Diff compares the definitions cfg implies against the agentic-* files on
+// disk. Files without Prefix are ignored entirely. A "remove" is reported
+// for an agentic-* file whose alias is no longer configured.
+func Diff(cfg *config.Config, dir string) ([]Change, error) {
+	want := map[string]Definition{}
+	for _, d := range Desired(cfg) {
+		want[d.Filename] = d
+	}
+
+	have := map[string][]byte{}
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, Prefix) || !strings.HasSuffix(name, ".md") {
+			continue // not ours
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		have[name] = data
+	}
+
+	var changes []Change
+	for fn, d := range want {
+		existing, ok := have[fn]
+		switch {
+		case !ok:
+			changes = append(changes, Change{Name: d.Name, Kind: "create"})
+		case string(existing) != d.Body:
+			changes = append(changes, Change{Name: d.Name, Kind: "update"})
+		}
+	}
+	for fn := range have {
+		if _, ok := want[fn]; !ok {
+			changes = append(changes, Change{Name: strings.TrimSuffix(fn, ".md"), Kind: "remove"})
+		}
+	}
+	sort.Slice(changes, func(i, j int) bool {
+		if changes[i].Kind != changes[j].Kind {
+			return changes[i].Kind < changes[j].Kind
+		}
+		return changes[i].Name < changes[j].Name
+	})
+	return changes, nil
+}
+
+// Sync writes the definitions cfg implies and removes stale agentic-* files.
+// Only files carrying Prefix are ever written or deleted.
+func Sync(cfg *config.Config, dir string) ([]Change, error) {
+	changes, err := Diff(cfg, dir)
+	if err != nil {
+		return nil, err
+	}
+	if len(changes) == 0 {
+		return nil, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	byName := map[string]Definition{}
+	for _, d := range Desired(cfg) {
+		byName[d.Name] = d
+	}
+	for _, c := range changes {
+		path := filepath.Join(dir, c.Name+".md")
+		if c.Kind == "remove" {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, err
+			}
+			continue
+		}
+		if err := os.WriteFile(path, []byte(byName[c.Name].Body), 0o644); err != nil {
+			return nil, err
+		}
+	}
+	return changes, nil
+}
+
+// Fingerprint hashes the definitions cfg implies. Used to remember that the
+// user declined a specific config state, so the launch-time offer stays
+// quiet until the aliases actually change again.
+func Fingerprint(cfg *config.Config) string {
+	h := sha256.New()
+	for _, d := range Desired(cfg) {
+		h.Write([]byte(d.Filename))
+		h.Write([]byte{0})
+		h.Write([]byte(d.Body))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil)[:8])
+}
+
+// declinedFile is where a declined fingerprint is remembered, inside the
+// agentic data dir (not ~/.claude — this is agentic's own state).
+func declinedFile(dataDir string) string {
+	return filepath.Join(dataDir, "agents-declined")
+}
+
+// Declined reports whether the user already said no to this exact config
+// state. Any read error means "not declined" — a missing or corrupt state
+// file must never suppress the offer silently.
+func Declined(dataDir, fingerprint string) bool {
+	data, err := os.ReadFile(declinedFile(dataDir))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == fingerprint
+}
+
+// RecordDeclined remembers that the user declined this config state.
+func RecordDeclined(dataDir, fingerprint string) error {
+	return os.WriteFile(declinedFile(dataDir), []byte(fingerprint+"\n"), 0o600)
+}
+
+// ClearDeclined forgets any declined state (called after a successful sync,
+// so a later change offers again).
+func ClearDeclined(dataDir string) {
+	os.Remove(declinedFile(dataDir))
+}

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -1,0 +1,208 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/maorbril/agentic/internal/config"
+)
+
+func testCfg(aliases ...string) *config.Config {
+	models := map[string]config.Model{}
+	for _, a := range aliases {
+		models[a] = config.Model{Provider: "p", ID: a + "-upstream"}
+	}
+	return &config.Config{
+		Providers: map[string]config.Provider{"p": {Type: config.ProviderOpenAI, BaseURL: "http://x"}},
+		Models:    models,
+	}
+}
+
+func TestSlug(t *testing.T) {
+	cases := map[string]string{
+		"qwen":        "qwen",
+		"gpt-5.6-sol": "gpt-5-6-sol", // dots are not safe in a name
+		"glm52":       "glm52",
+		"GPT_4o":      "gpt-4o",
+		"a..b":        "a-b", // separator runs collapse
+		"-lead-":      "lead",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// The whole feature rests on the frontmatter carrying the alias verbatim —
+// that string is what reaches the router.
+func TestDesiredEmitsAliasAsModel(t *testing.T) {
+	got := Desired(testCfg("gpt-5.6-sol"))
+	if len(got) != 1 {
+		t.Fatalf("got %d definitions, want 1", len(got))
+	}
+	d := got[0]
+	if d.Name != "agentic-gpt-5-6-sol" || d.Filename != "agentic-gpt-5-6-sol.md" {
+		t.Errorf("name=%q file=%q", d.Name, d.Filename)
+	}
+	if !strings.Contains(d.Body, "\nmodel: gpt-5.6-sol\n") {
+		t.Errorf("body must carry the raw alias in model frontmatter:\n%s", d.Body)
+	}
+	if !strings.Contains(d.Body, "name: agentic-gpt-5-6-sol") {
+		t.Errorf("body must declare the slugged name:\n%s", d.Body)
+	}
+}
+
+// Routing rules are classifier rules, not concrete models — a subagent that
+// silently re-tiers itself would make the chosen model unpredictable.
+func TestDesiredExcludesRoutingRules(t *testing.T) {
+	cfg := testCfg("opus", "qwen")
+	cfg.Routing = map[string]config.RouteRule{
+		"auto": {Classifier: "qwen", Tiers: map[string]string{"deep": "opus"}},
+	}
+	for _, d := range Desired(cfg) {
+		if d.Alias == "auto" {
+			t.Error("routing rule 'auto' must not get a subagent")
+		}
+	}
+	if len(Desired(cfg)) != 2 {
+		t.Errorf("want 2 definitions (opus, qwen), got %d", len(Desired(cfg)))
+	}
+}
+
+func TestDiffAndSyncRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testCfg("qwen", "opus")
+
+	// Everything is new.
+	changes, err := Diff(cfg, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("want 2 creates, got %+v", changes)
+	}
+
+	if _, err := Sync(cfg, dir); err != nil {
+		t.Fatal(err)
+	}
+	// Now in sync: no changes, and Sync is a no-op.
+	if changes, _ := Diff(cfg, dir); len(changes) != 0 {
+		t.Errorf("after sync, want no changes, got %+v", changes)
+	}
+	if applied, _ := Sync(cfg, dir); len(applied) != 0 {
+		t.Errorf("second sync should be a no-op, got %+v", applied)
+	}
+
+	// Dropping an alias makes its file stale.
+	smaller := testCfg("qwen")
+	changes, _ = Diff(smaller, dir)
+	if len(changes) != 1 || changes[0].Kind != "remove" || changes[0].Name != "agentic-opus" {
+		t.Fatalf("want remove of agentic-opus, got %+v", changes)
+	}
+	if _, err := Sync(smaller, dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "agentic-opus.md")); !os.IsNotExist(err) {
+		t.Error("stale agentic-opus.md should have been removed")
+	}
+}
+
+// The safety property that matters most: a user's own agents are never read,
+// written, or deleted — only the agentic- prefix is owned.
+func TestSyncNeverTouchesForeignFiles(t *testing.T) {
+	dir := t.TempDir()
+	foreign := filepath.Join(dir, "my-reviewer.md")
+	const body = "---\nname: my-reviewer\nmodel: opus\n---\nmine, hands off\n"
+	if err := os.WriteFile(foreign, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Sync(testCfg("qwen"), dir); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(foreign)
+	if err != nil {
+		t.Fatalf("foreign agent was removed: %v", err)
+	}
+	if string(got) != body {
+		t.Error("foreign agent was rewritten")
+	}
+	// It must not even be reported as stale.
+	for _, c := range mustDiff(t, testCfg("qwen"), dir) {
+		if c.Name == "my-reviewer" {
+			t.Error("foreign agent must not appear in the diff")
+		}
+	}
+}
+
+// A hand-edited agentic-* file is reported as an update so sync can restore
+// it — that file is ours by prefix.
+func TestDiffDetectsHandEditedOwnedFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testCfg("qwen")
+	if _, err := Sync(cfg, dir); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "agentic-qwen.md")
+	if err := os.WriteFile(path, []byte("tampered\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	changes := mustDiff(t, cfg, dir)
+	if len(changes) != 1 || changes[0].Kind != "update" {
+		t.Fatalf("want one update, got %+v", changes)
+	}
+}
+
+func TestDiffMissingDirIsAllCreates(t *testing.T) {
+	changes, err := Diff(testCfg("qwen"), filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatalf("missing dir must not error: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Kind != "create" {
+		t.Errorf("want one create, got %+v", changes)
+	}
+}
+
+func TestFingerprintTracksConfig(t *testing.T) {
+	a := Fingerprint(testCfg("qwen"))
+	if a != Fingerprint(testCfg("qwen")) {
+		t.Error("fingerprint must be stable for the same config")
+	}
+	if a == Fingerprint(testCfg("qwen", "opus")) {
+		t.Error("adding an alias must change the fingerprint")
+	}
+}
+
+func TestDeclinedState(t *testing.T) {
+	dir := t.TempDir()
+	fp := Fingerprint(testCfg("qwen"))
+	if Declined(dir, fp) {
+		t.Error("nothing recorded yet")
+	}
+	if err := RecordDeclined(dir, fp); err != nil {
+		t.Fatal(err)
+	}
+	if !Declined(dir, fp) {
+		t.Error("should be declined after recording")
+	}
+	// A different config state is not covered by the old decline.
+	if Declined(dir, Fingerprint(testCfg("qwen", "opus"))) {
+		t.Error("a changed config must ask again")
+	}
+	ClearDeclined(dir)
+	if Declined(dir, fp) {
+		t.Error("cleared state should not be declined")
+	}
+}
+
+func mustDiff(t *testing.T, cfg *config.Config, dir string) []Change {
+	t.Helper()
+	c, err := Diff(cfg, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}

--- a/internal/launch/agentsync.go
+++ b/internal/launch/agentsync.go
@@ -1,0 +1,118 @@
+package launch
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/maorbril/agentic/internal/agents"
+	"github.com/maorbril/agentic/internal/config"
+)
+
+// offerAgentSync prompts once, at launch, when the generated subagents have
+// drifted from the configured model aliases. Deliberately quiet: it says
+// nothing when in sync, when not attached to a terminal (piped/headless runs
+// must never block on input), when AGENTIC_NO_AGENT_SYNC is set, or when the
+// user already declined this exact config state.
+func offerAgentSync(cfg *config.Config, dataDir string) {
+	if os.Getenv("AGENTIC_NO_AGENT_SYNC") != "" {
+		return
+	}
+	if !isInteractive() {
+		return
+	}
+	dir, err := agents.Dir()
+	if err != nil {
+		return
+	}
+	changes, err := agents.Diff(cfg, dir)
+	if err != nil || len(changes) == 0 {
+		return // in sync (or unreadable) — stay silent
+	}
+	fp := agents.Fingerprint(cfg)
+	if agents.Declined(dataDir, fp) {
+		return // already said no to this exact state
+	}
+
+	fmt.Fprintf(os.Stderr, "\nagentic: %s\n", summarize(changes))
+	fmt.Fprintf(os.Stderr, "  These let you target a specific model by name (e.g. subagent_type: %q).\n",
+		firstName(changes))
+	fmt.Fprint(os.Stderr, "  Update ~/.claude/agents now? [y/N] ")
+
+	if !readYes() {
+		if err := agents.RecordDeclined(dataDir, fp); err == nil {
+			fmt.Fprintln(os.Stderr, "  skipped — won't ask again until your model aliases change (`agentic agents sync` anytime)")
+		}
+		return
+	}
+	applied, err := agents.Sync(cfg, dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ could not write subagents: %v\n", err)
+		return
+	}
+	agents.ClearDeclined(dataDir)
+	fmt.Fprintf(os.Stderr, "  ✓ synced %d subagent(s) — available in new sessions\n", len(applied))
+}
+
+func summarize(changes []agents.Change) string {
+	var create, update, remove int
+	for _, c := range changes {
+		switch c.Kind {
+		case "create":
+			create++
+		case "update":
+			update++
+		case "remove":
+			remove++
+		}
+	}
+	var parts []string
+	if create > 0 {
+		parts = append(parts, fmt.Sprintf("%d new", create))
+	}
+	if update > 0 {
+		parts = append(parts, fmt.Sprintf("%d changed", update))
+	}
+	if remove > 0 {
+		parts = append(parts, fmt.Sprintf("%d stale", remove))
+	}
+	return "model-alias subagents out of date (" + strings.Join(parts, ", ") + ")"
+}
+
+// firstName returns a created/updated subagent name for the example line,
+// preferring one the user will actually gain.
+func firstName(changes []agents.Change) string {
+	for _, c := range changes {
+		if c.Kind == "create" {
+			return c.Name
+		}
+	}
+	return changes[0].Name
+}
+
+// isInteractive reports whether stdin and stderr are both terminals, so a
+// prompt can be shown and answered.
+func isInteractive() bool {
+	return isTerminal(os.Stdin) && isTerminal(os.Stderr)
+}
+
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
+func readYes() bool {
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	}
+	return false
+}

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -119,6 +119,11 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 			recordSession(dataDir, sessionID, profName, false)
 			printSummary(dataDir, cfg, sessionID, profName)
 		}()
+
+		// Offer to refresh the per-alias subagents when they've drifted from
+		// config. Router-backed sessions only — a passthrough profile doesn't
+		// resolve agentic aliases, so the generated agents wouldn't work there.
+		offerAgentSync(cfg, dataDir)
 	}
 
 	child := buildChild(opts)


### PR DESCRIPTION
## Problem

A subagent in another session reported: *"The available agent registry doesn't expose `gpt-5.6-sol` as a selectable model here."*

Root cause: Claude Code's built-in Agent tool has a **hardcoded** `model` enum — `sonnet | opus | haiku | fable`. That's the tool-call schema the orchestrating model must obey, so no router change can widen it. Subagents are effectively pinned to the Claude tiers even when the right tool for the job is a routed alias.

## What actually works

A subagent **definition's** `model:` frontmatter has no such restriction — and behind a custom `ANTHROPIC_BASE_URL` (which agentic always sets) Claude Code passes the string through **unvalidated**, straight to the router. So a generated definition per alias makes every configured model selectable by name.

## Why this is portable, not machine-specific

The definitions are generated from the user's own `models:` map. On my machine that yields `agentic-gpt-5-6-sol`, `agentic-glm52`, `agentic-grok`, …; on a fresh install with different aliases it yields *theirs*. Nothing is hardcoded — the alias list is the same one `agentic models list` prints.

Routing rules (e.g. `auto`) are deliberately **excluded**: they're classifier rules, and a subagent that silently re-tiers itself would make the chosen model unpredictable.

## Interface

```bash
agentic agents list   # what your config implies, and what's pending
agentic agents sync   # write ~/.claude/agents/agentic-<alias>.md
```

Plus a launch-time offer that is quiet by design: it speaks **only** on real drift, **only** on a TTY (a prompt in a piped/headless run would hang sessions), and remembers a declined config fingerprint so it re-asks exactly when the aliases change. `AGENTIC_NO_AGENT_SYNC=1` opts out.

**Safety**: only files prefixed `agentic-` are ever read, written, or deleted — mirroring how `registerStatusline` leaves an existing statusline alone. A user's hand-written agents are never touched, and never even appear in the diff.

## Verification

- 9 unit tests in `internal/agents`, including the load-bearing ones: the alias reaches `model:` frontmatter verbatim; routing rules are excluded; foreign files are neither rewritten nor reported; a hand-edited `agentic-*` file is restorable; a missing dir is all-creates; declined state tracks config changes.
- Non-interactive launch confirmed a no-op (no prompt, no hang).
- **Live end-to-end**: generated into a sandbox HOME, ran real headless Claude Code invoking `subagent_type: "agentic-gpt-5-6-sol"`, got the right answer back — and the router log proves the routing:
  ```
  1 model=gpt-5.6-sol upstream=glm-52-fp8-mi325 status=200   <- the subagent
  4 model=glm52       upstream=glm-52-fp8-mi325 status=200   <- main session
  ```
- Full suite green (`go build`, `go vet`, `go test ./...`, `gofmt`).

## Note

Existing sessions won't see new agents until restarted — `agentic update`'s restart report already covers that class of "running binary vs new config" drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)