### PR TITLE
Sanitize translated tool-use IDs

### DIFF
--- a/internal/backend/anthropicbe/normalize.go
+++ b/internal/backend/anthropicbe/normalize.go
@@ -24,6 +24,13 @@ func rewriteForModel(raw []byte, model string) ([]byte, error) {
 }
 
 func normalizeForModel(m map[string]any, model string) {
+	// A history may contain tool ids emitted earlier by an OpenAI-compatible
+	// backend (notably vLLM ids like "Bash:0"). Anthropic validates both
+	// tool_use.id and matching tool_result.tool_use_id against
+	// ^[A-Za-z0-9_-]+$; normalize the pair in-flight so already-persisted
+	// transcripts recover automatically without destructive file edits.
+	sanitizeToolIDs(m)
+
 	switch {
 	case strings.HasPrefix(model, "claude-fable") || strings.HasPrefix(model, "claude-mythos"):
 		// Thinking is always on; any explicit config (enabled, disabled,
@@ -68,6 +75,101 @@ func normalizeForModel(m map[string]any, model string) {
 
 // supportsEffort reports whether the model accepts output_config.effort
 // (Opus 4.5+, Sonnet 4.6+, Fable/Mythos; Haiku and older Sonnets reject it).
+// hasInvalidToolID reports whether raw request history contains a tool id
+// outside Anthropic's accepted character set. It intentionally parses only
+// the small envelope needed to preserve byte-faithful passthrough for clean
+// requests; malformed JSON is handled later by rewriteForModel.
+func hasInvalidToolID(raw []byte) bool {
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil {
+		return false
+	}
+	msgs, _ := m["messages"].([]any)
+	for _, rawMsg := range msgs {
+		msg, _ := rawMsg.(map[string]any)
+		blocks, _ := msg["content"].([]any)
+		for _, rawBlock := range blocks {
+			block, _ := rawBlock.(map[string]any)
+			var id string
+			switch block["type"] {
+			case "tool_use":
+				id, _ = block["id"].(string)
+			case "tool_result":
+				id, _ = block["tool_use_id"].(string)
+			}
+			if id != "" && validToolID(id) != id {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// sanitizeToolIDs rewrites every invalid tool_use.id and
+// tool_result.tool_use_id in messages[] with the same deterministic mapping,
+// preserving their references while satisfying Anthropic's id validation.
+func sanitizeToolIDs(m map[string]any) {
+	msgs, ok := m["messages"].([]any)
+	if !ok {
+		return
+	}
+	for _, raw := range msgs {
+		msg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		blocks, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		for _, rawBlock := range blocks {
+			block, ok := rawBlock.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch block["type"] {
+			case "tool_use":
+				if id, ok := block["id"].(string); ok {
+					block["id"] = validToolID(id)
+				}
+			case "tool_result":
+				if id, ok := block["tool_use_id"].(string); ok {
+					block["tool_use_id"] = validToolID(id)
+				}
+			}
+		}
+	}
+}
+
+func validToolID(id string) string {
+	if id == "" {
+		return "toolu_agentic_missing"
+	}
+	clean := true
+	for _, r := range id {
+		if !validToolIDRune(r) {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return id
+	}
+	out := make([]rune, 0, len(id))
+	for _, r := range id {
+		if validToolIDRune(r) {
+			out = append(out, r)
+		} else {
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}
+
+func validToolIDRune(r rune) bool {
+	return r == '_' || r == '-' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
 func supportsEffort(model string) bool {
 	for _, prefix := range []string{
 		"claude-fable", "claude-mythos",

--- a/internal/backend/anthropicbe/passthrough.go
+++ b/internal/backend/anthropicbe/passthrough.go
@@ -35,8 +35,11 @@ func (b *Backend) CountTokens(ctx context.Context, call *backend.Call, w http.Re
 func (b *Backend) forward(ctx context.Context, call *backend.Call, w http.ResponseWriter, path string, tee bool) backend.Result {
 	body := call.Raw
 	// Byte-faithful when the alias already is the upstream model id —
-	// cache_control, thinking blocks, and unknown future fields survive.
-	if call.Envelope.Model != call.Route.Model.ID {
+	// cache_control, thinking blocks, and unknown future fields survive. The
+	// exception is a poisoned history containing a non-Anthropic tool id
+	// (e.g. vLLM's "Bash:0"): that request must be parsed so the matching
+	// tool_use/tool_result ids can be repaired before Anthropic rejects it.
+	if call.Envelope.Model != call.Route.Model.ID || hasInvalidToolID(call.Raw) {
 		var err error
 		body, err = rewriteForModel(call.Raw, call.Route.Model.ID)
 		if err != nil {

--- a/internal/backend/anthropicbe/passthrough_test.go
+++ b/internal/backend/anthropicbe/passthrough_test.go
@@ -66,6 +66,35 @@ func TestByteFaithfulPassthrough(t *testing.T) {
 	}
 }
 
+func TestPoisonedToolIDsAreRepairedForAnthropic(t *testing.T) {
+	body := `{"model":"claude-sonnet-5","max_tokens":100,"messages":[` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"Bash:0","name":"Bash","input":{"command":"ls"}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"Bash:0","content":"ok"}]}` +
+		`]}`
+	var got map[string]any
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatal(err)
+		}
+		w.Write([]byte(`{"usage":{}}`))
+	}))
+	defer up.Close()
+
+	// alias == upstream model: this normally takes the byte-faithful path,
+	// but a poisoned history must be rewritten so an existing session can
+	// recover without editing its transcript on disk.
+	call := mkCall(t, body, up.URL, "claude-sonnet-5")
+	New().Messages(context.Background(), call, httptest.NewRecorder())
+
+	msgs := got["messages"].([]any)
+	toolUse := msgs[0].(map[string]any)["content"].([]any)[0].(map[string]any)
+	toolResult := msgs[1].(map[string]any)["content"].([]any)[0].(map[string]any)
+	if toolUse["id"] != "Bash_0" || toolResult["tool_use_id"] != "Bash_0" {
+		t.Fatalf("matching ids not repaired: tool_use=%v tool_result=%v", toolUse["id"], toolResult["tool_use_id"])
+	}
+}
+
 func TestModelRewriteOnlyTouchesModel(t *testing.T) {
 	body := `{"model":"cheap","max_tokens":100,"temperature":0.5,"messages":[]}`
 	var gotBody map[string]json.RawMessage

--- a/internal/backend/openaibe/response.go
+++ b/internal/backend/openaibe/response.go
@@ -61,7 +61,38 @@ func toolUseID(id string) string {
 	if id == "" {
 		return "toolu_agentic_missing"
 	}
-	return id
+	return sanitizeToolUseID(id)
+}
+
+// sanitizeToolUseID maps an upstream tool-call id onto the character set the
+// Anthropic API validates tool_use.id against (letters, digits, "_", "-").
+// vLLM and some OpenAI-compatible backends emit ids like "Bash:0" —
+// Claude Code persists that block verbatim into its transcript, and once
+// persisted, every future turn that resends it to a real Anthropic model
+// 400s on invalid_request_error until the transcript is edited by hand. This
+// keeps the id round-trippable (translateMessage's reverse direction reads
+// the same string back off tool_result.tool_use_id) while guaranteeing it
+// can never reach Anthropic's API unsanitized.
+func sanitizeToolUseID(id string) string {
+	clean := true
+	for _, r := range id {
+		if !(r == '_' || r == '-' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+			clean = false
+			break
+		}
+	}
+	if clean {
+		return id
+	}
+	out := make([]rune, 0, len(id))
+	for _, r := range id {
+		if r == '_' || r == '-' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			out = append(out, r)
+		} else {
+			out = append(out, '_')
+		}
+	}
+	return string(out)
 }
 
 func mapFinishReason(fr string, hasToolCalls bool) string {

--- a/internal/backend/openaibe/stream.go
+++ b/internal/backend/openaibe/stream.go
@@ -231,6 +231,8 @@ func (s *streamState) openToolBlock() {
 	id := s.pendingID
 	if id == "" {
 		id = "toolu_agentic_missing"
+	} else {
+		id = sanitizeToolUseID(id)
 	}
 	s.sse.Event("content_block_start", map[string]any{
 		"type": "content_block_start", "index": s.index,

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -195,6 +195,26 @@ func TestStreamSplitToolHeader(t *testing.T) {
 	}
 }
 
+// Anthropic's tool_use.id must match ^[A-Za-z0-9_-]+$; vLLM-style ids like
+// "Bash:0" persisted verbatim into Claude Code's transcript 400 on every
+// later turn that resends the history to a real Anthropic model.
+func TestStreamOpenToolBlockSanitizesID(t *testing.T) {
+	evs := runStream(t, []string{
+		`{"id":"c9","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"Bash:0","function":{"name":"Bash","arguments":"{}"}}]}}]}`,
+		`{"id":"c9","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	})
+	for _, e := range evs {
+		if e.name == "content_block_start" {
+			cb := e.data["content_block"].(map[string]any)
+			if cb["type"] == "tool_use" {
+				if cb["id"] != "Bash_0" {
+					t.Errorf("tool_use id = %v, want sanitized \"Bash_0\"", cb["id"])
+				}
+			}
+		}
+	}
+}
+
 func TestStreamToolCallsWithoutIndex(t *testing.T) {
 	// Providers that omit tool_calls[].index (some xAI/OpenRouter/vLLM
 	// builds) signal a new call with a fresh id; args-only fragments carry

--- a/internal/backend/openaibe/translate_test.go
+++ b/internal/backend/openaibe/translate_test.go
@@ -232,3 +232,48 @@ func TestRepairJSON(t *testing.T) {
 		}
 	}
 }
+
+// Anthropic's API validates tool_use.id against ^[A-Za-z0-9_-]+$. vLLM and
+// some other OpenAI-compatible backends emit ids like "Bash:0" — passed
+// through unsanitized, Claude Code persists that into its transcript, and
+// every later turn that resends the history to a real Anthropic model 400s
+// on invalid_request_error until the transcript is hand-edited.
+func TestToolUseIDSanitizesInvalidCharacters(t *testing.T) {
+	cases := map[string]string{
+		"Bash:0":                      "Bash_0",
+		"TaskOutput:12":               "TaskOutput_12",
+		"call_a":                      "call_a",
+		"toolu_1":                     "toolu_1",
+		"":                            "toolu_agentic_missing",
+		"functions.read_file:0":       "functions_read_file_0",
+		"mcp__clauder__get_context:0": "mcp__clauder__get_context_0",
+	}
+	for in, want := range cases {
+		if got := toolUseID(in); got != want {
+			t.Errorf("toolUseID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResponseTranslationSanitizesToolCallID(t *testing.T) {
+	resp := &openai.ChatResponse{
+		ID: "chatcmpl-abc",
+		Choices: []openai.Choice{{
+			Message: openai.ResponseMessage{
+				Role: "assistant",
+				ToolCalls: []openai.ToolCall{{
+					ID: "Bash:0", Type: "function",
+					Function: openai.FunctionCall{Name: "Bash", Arguments: `{"command":"ls"}`},
+				}},
+			},
+			FinishReason: "tool_calls",
+		}},
+	}
+	out, err := TranslateResponse(resp, "gpt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Content[0].ID != "Bash_0" {
+		t.Errorf("tool_use.id = %q, want sanitized id without colon", out.Content[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary

- sanitize OpenAI/vLLM tool-call IDs before emitting Anthropic `tool_use` blocks in streaming and non-streaming responses
- repair matching `tool_use.id` / `tool_result.tool_use_id` pairs in-flight when an already-poisoned transcript is routed to Anthropic
- preserve byte-faithful Anthropic passthrough for clean requests
- add regression tests for both new responses and persisted histories

## Why

Some OpenAI-compatible providers emit IDs such as `Bash:0`. Anthropic validates tool IDs against `^[A-Za-z0-9_-]+$`; once Claude Code persists an invalid ID, every later Anthropic-routed turn fails with a 400. The request-side repair lets existing sessions recover without destructive transcript edits.

## Verification

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)