### PR TITLE
Repair unsigned translated thinking on cross-tier replay

### DIFF
--- a/internal/backend/anthropicbe/normalize.go
+++ b/internal/backend/anthropicbe/normalize.go
@@ -30,6 +30,7 @@ func normalizeForModel(m map[string]any, model string) {
 	// ^[A-Za-z0-9_-]+$; normalize the pair in-flight so already-persisted
 	// transcripts recover automatically without destructive file edits.
 	sanitizeToolIDs(m)
+	stripUnsignedThinking(m)
 
 	switch {
 	case strings.HasPrefix(model, "claude-fable") || strings.HasPrefix(model, "claude-mythos"):
@@ -103,6 +104,79 @@ func hasInvalidToolID(raw []byte) bool {
 		}
 	}
 	return false
+}
+
+// hasUnsignedThinking reports whether translated reasoning has been replayed
+// as an Anthropic thinking block without a real signature. Claude Code keeps
+// response blocks in history; Anthropic rejects these display-only blocks on
+// a later cross-tier turn unless the passthrough takes the repair path.
+func hasUnsignedThinking(raw []byte) bool {
+	var m map[string]any
+	if json.Unmarshal(raw, &m) != nil {
+		return false
+	}
+	msgs, _ := m["messages"].([]any)
+	for _, rawMsg := range msgs {
+		msg, _ := rawMsg.(map[string]any)
+		if msg["role"] != "assistant" {
+			continue
+		}
+		blocks, _ := msg["content"].([]any)
+		for _, rawBlock := range blocks {
+			block, _ := rawBlock.(map[string]any)
+			if block["type"] == "thinking" && !hasThinkingSignature(block) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// stripUnsignedThinking removes only display-only reasoning minted by an
+// OpenAI-compatible backend. Genuine Anthropic thinking has a non-empty
+// signature and must be replayed byte-for-byte; redacted_thinking uses a
+// different data field and is never touched.
+func stripUnsignedThinking(m map[string]any) {
+	msgs, ok := m["messages"].([]any)
+	if !ok {
+		return
+	}
+	for _, rawMsg := range msgs {
+		msg, ok := rawMsg.(map[string]any)
+		if !ok || msg["role"] != "assistant" {
+			continue
+		}
+		blocks, ok := msg["content"].([]any)
+		if !ok {
+			continue
+		}
+		out := make([]any, 0, len(blocks))
+		var reasoning string
+		for _, rawBlock := range blocks {
+			block, ok := rawBlock.(map[string]any)
+			if !ok || block["type"] != "thinking" || hasThinkingSignature(block) {
+				out = append(out, rawBlock)
+				continue
+			}
+			if text, ok := block["thinking"].(string); ok && strings.TrimSpace(text) != "" {
+				if reasoning != "" {
+					reasoning += "\n"
+				}
+				reasoning += text
+			}
+		}
+		if len(out) == 0 && reasoning != "" {
+			// A reasoning-only translated response would otherwise become an
+			// invalid empty assistant message. Preserve it as ordinary context.
+			out = append(out, map[string]any{"type": "text", "text": reasoning})
+		}
+		msg["content"] = out
+	}
+}
+
+func hasThinkingSignature(block map[string]any) bool {
+	signature, ok := block["signature"].(string)
+	return ok && signature != ""
 }
 
 // sanitizeToolIDs rewrites every invalid tool_use.id and

--- a/internal/backend/anthropicbe/passthrough.go
+++ b/internal/backend/anthropicbe/passthrough.go
@@ -36,10 +36,10 @@ func (b *Backend) forward(ctx context.Context, call *backend.Call, w http.Respon
 	body := call.Raw
 	// Byte-faithful when the alias already is the upstream model id —
 	// cache_control, thinking blocks, and unknown future fields survive. The
-	// exception is a poisoned history containing a non-Anthropic tool id
-	// (e.g. vLLM's "Bash:0"): that request must be parsed so the matching
-	// tool_use/tool_result ids can be repaired before Anthropic rejects it.
-	if call.Envelope.Model != call.Route.Model.ID || hasInvalidToolID(call.Raw) {
+	// exceptions are poisoned history from a translated backend: invalid
+	// tool ids (e.g. vLLM's "Bash:0") and unsigned display-only thinking.
+	// Those requests must be parsed and repaired before Anthropic rejects them.
+	if call.Envelope.Model != call.Route.Model.ID || hasInvalidToolID(call.Raw) || hasUnsignedThinking(call.Raw) {
 		var err error
 		body, err = rewriteForModel(call.Raw, call.Route.Model.ID)
 		if err != nil {

--- a/internal/backend/anthropicbe/passthrough_test.go
+++ b/internal/backend/anthropicbe/passthrough_test.go
@@ -95,6 +95,102 @@ func TestPoisonedToolIDsAreRepairedForAnthropic(t *testing.T) {
 	}
 }
 
+func TestUnsignedThinkingIsRepairedForAnthropic(t *testing.T) {
+	cases := []struct {
+		name     string
+		thinking string
+	}{
+		{"absent signature", `{"type":"thinking","thinking":"translated reasoning"}`},
+		{"empty signature", `{"type":"thinking","thinking":"translated reasoning","signature":""}`},
+		{"null signature", `{"type":"thinking","thinking":"translated reasoning","signature":null}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"model":"claude-sonnet-5","max_tokens":100,"messages":[` +
+				`{"role":"user","content":"hi"},` +
+				`{"role":"assistant","content":[` + tc.thinking + `,{"type":"text","text":"answer"}]},` +
+				`{"role":"user","content":"continue"}]}`
+			var got map[string]any
+			up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				if err := json.Unmarshal(raw, &got); err != nil {
+					t.Fatal(err)
+				}
+				w.Write([]byte(`{"usage":{}}`))
+			}))
+			defer up.Close()
+
+			// alias == upstream normally stays byte-faithful; unsigned thinking
+			// must still force normalization so existing transcripts self-heal.
+			call := mkCall(t, body, up.URL, "claude-sonnet-5")
+			New().Messages(context.Background(), call, httptest.NewRecorder())
+
+			blocks := got["messages"].([]any)[1].(map[string]any)["content"].([]any)
+			if len(blocks) != 1 || blocks[0].(map[string]any)["type"] != "text" {
+				t.Fatalf("assistant content = %#v, want only text", blocks)
+			}
+		})
+	}
+}
+
+func TestThinkingRepairPreservesAnthropicBlocks(t *testing.T) {
+	body := `{"model":"alias","max_tokens":100,"messages":[` +
+		`{"role":"assistant","content":[` +
+		`{"type":"thinking","thinking":"signed","signature":"sig_abc"},` +
+		`{"type":"redacted_thinking","data":"encrypted"},` +
+		`{"type":"text","text":"answer"}]},` +
+		`{"role":"user","content":[{"type":"thinking","thinking":"user content"}]}]}`
+	var got map[string]any
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatal(err)
+		}
+		w.Write([]byte(`{"usage":{}}`))
+	}))
+	defer up.Close()
+
+	// Alias rewrite exercises normalizeForModel without requiring poison.
+	call := mkCall(t, body, up.URL, "claude-sonnet-5")
+	New().Messages(context.Background(), call, httptest.NewRecorder())
+
+	msgs := got["messages"].([]any)
+	assistant := msgs[0].(map[string]any)["content"].([]any)
+	if len(assistant) != 3 || assistant[0].(map[string]any)["signature"] != "sig_abc" ||
+		assistant[1].(map[string]any)["type"] != "redacted_thinking" {
+		t.Fatalf("signed/redacted thinking changed: %#v", assistant)
+	}
+	user := msgs[1].(map[string]any)["content"].([]any)
+	if len(user) != 1 || user[0].(map[string]any)["type"] != "thinking" {
+		t.Fatalf("user content changed: %#v", user)
+	}
+}
+
+func TestReasoningOnlyAssistantBecomesText(t *testing.T) {
+	body := `{"model":"claude-sonnet-5","max_tokens":100,"messages":[` +
+		`{"role":"user","content":"hi"},` +
+		`{"role":"assistant","content":[{"type":"thinking","thinking":"translated reasoning","signature":""}]},` +
+		`{"role":"user","content":"continue"}]}`
+	var got map[string]any
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatal(err)
+		}
+		w.Write([]byte(`{"usage":{}}`))
+	}))
+	defer up.Close()
+
+	call := mkCall(t, body, up.URL, "claude-sonnet-5")
+	New().Messages(context.Background(), call, httptest.NewRecorder())
+
+	blocks := got["messages"].([]any)[1].(map[string]any)["content"].([]any)
+	if len(blocks) != 1 || blocks[0].(map[string]any)["type"] != "text" ||
+		blocks[0].(map[string]any)["text"] != "translated reasoning" {
+		t.Fatalf("assistant content = %#v", blocks)
+	}
+}
+
 func TestModelRewriteOnlyTouchesModel(t *testing.T) {
 	body := `{"model":"cheap","max_tokens":100,"temperature":0.5,"messages":[]}`
 	var gotBody map[string]json.RawMessage

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -164,6 +164,15 @@ func TestStreamReasoningContent(t *testing.T) {
 	if strings.Join(seen, " ") != want {
 		t.Errorf("block sequence:\n got %s\nwant %s", strings.Join(seen, " "), want)
 	}
+	for _, e := range evs {
+		if e.name != "content_block_delta" {
+			continue
+		}
+		delta := e.data["delta"].(map[string]any)
+		if delta["type"] == "signature_delta" && delta["signature"] != "" {
+			t.Errorf("translated thinking signature = %v, want empty display-only marker", delta["signature"])
+		}
+	}
 }
 
 func TestStreamSplitToolHeader(t *testing.T) {

--- a/internal/backend/openaibe/translate_test.go
+++ b/internal/backend/openaibe/translate_test.go
@@ -206,6 +206,15 @@ func TestResponseTranslation(t *testing.T) {
 	if out.Content[0].Type != "thinking" || out.Content[1].Type != "text" || out.Content[2].Type != "tool_use" {
 		t.Fatalf("block order: %+v", out.Content)
 	}
+	// Translated reasoning is display-only: ContentBlock intentionally has no
+	// signature field, so native Anthropic replay can identify and strip it.
+	encoded, err := json.Marshal(out.Content[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), `"signature"`) {
+		t.Errorf("translated thinking unexpectedly has a signature: %s", encoded)
+	}
 	// truncated arguments repaired
 	var input map[string]any
 	if err := json.Unmarshal(out.Content[2].Input, &input); err != nil || input["path"] != "a.go" {


### PR DESCRIPTION
## Problem

Tool use itself works on `kimi-k3`, but sessions using `model: auto` could enter a repeatable `[Tool use interrupted]` loop after a tier switch:

1. an OpenAI-compatible reasoning model emits display-only reasoning;
2. agentic translates it to an Anthropic-shaped `thinking` block without a valid cryptographic signature;
3. Claude Code persists that block in history;
4. a later turn routes to native Anthropic, which rejects the replay with `400 Invalid signature`;
5. retries replay the same poisoned history and fail again.

## Fix

- force request normalization when assistant history contains unsigned thinking, even when alias == upstream model and native passthrough would otherwise be byte-faithful
- remove only `thinking` blocks with absent, empty, or non-string signatures
- preserve genuine signed Anthropic thinking and `redacted_thinking` unchanged
- preserve reasoning-only translated responses as ordinary text instead of producing an invalid empty assistant message
- keep translated reasoning visible and leave direct kimi tool use unchanged

Existing poisoned sessions self-heal on their next native Anthropic request; no transcript editing is required.

## Verification

- focused backend/router tests
- full `go test ./...`, `go vet ./...`, `go build ./...`, gofmt, diff check
- isolated live router reproduction: previously-poisoned replay to `sonnet` succeeds with `end_turn`
- direct `kimi-k3` tool-use probe still succeeds with `stop_reason: tool_use`

🤖 Generated with [Claude Code](https://claude.com/claude-code)