### PR TITLE
Launch claude directly now that session messaging is native

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There are three ways people solve "I want Claude Code but not locked to one prov
 | **Runs as** | Static Go binary, no daemon (leader election over a fixed port) | Daemon / server process you deploy and administer | Standalone CLI you run instead of Claude Code |
 | **Cost & budgets** | First-class CLI: `agentic cost`, live statusline, hard-stop daily/weekly/monthly budgets | Usually a dashboard (LiteLLM) or not built in | Varies by tool, rarely budget-gated |
 | **Model routing** | Aliases + a built-in LLM-classifier tier router (`auto`), sticky per turn | Rule-based routing configs; no classifier-based tiering | Manual model switch, no auto-routing |
-| **Memory / cross-instance** | Composes with [clauder](https://github.com/MaorBril/clauder) — separate binary, optional | Not their concern | Varies |
+| **Memory** | Composes with [clauder](https://github.com/MaorBril/clauder) — separate binary, optional | Not their concern | Varies |
 
 The short version: agentic doesn't try to be a better harness than Claude Code — it keeps Claude Code exactly as Anthropic ships it and only swaps what's behind `ANTHROPIC_BASE_URL`. If you want a different agent loop altogether, OpenCode/Crush/Goose/Aider are the right layer to look at instead. If you want a gateway you deploy and administer for a team, LiteLLM is a more mature choice for that. agentic is for a single developer who wants `claude`, unmodified, with a budget and a cheap-model escape hatch, installed in one command and running with nothing to operate.
 
@@ -236,7 +236,11 @@ When your aliases change, the next `agentic` launch offers to refresh them (once
 
 ## Works with clauder
 
-If [clauder](https://github.com/MaorBril/clauder) is installed, agentic launches sessions through `clauder wrap --slave`, so your instances get persistent memory, can message each other, and run with clauder's auto-approved tool set for autonomous operation. Launch with `--no-clauder` for a bare claude session. The two tools are independent; each works without the other.
+agentic spawns `claude` directly and grants each session an auto-approved tool set for autonomous operation (`Read Write Edit Glob Grep Bash(*) WebFetch WebSearch mcp__clauder__*`). `--name` becomes claude's own session name.
+
+Cross-instance messaging is native to Claude Code — sessions register under `~/.claude/sessions` and reach each other over a peer socket — so agentic no longer launches through `clauder wrap`. [clauder](https://github.com/MaorBril/clauder) remains a useful companion for **persistent memory**, which it provides over its own MCP server registration and therefore works no matter how the session was started. The two tools are independent; each works without the other.
+
+`--no-clauder` is accepted but deprecated: every session is a bare claude now, so there is no wrap layer to opt out of.
 
 ## Commands
 

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -18,9 +18,11 @@ func ensureClaude() bool {
 }
 
 // ensureClauder checks for the clauder binary and, if missing, offers to
-// install it. clauder is optional — agentic works without it.
+// install it. clauder is optional — agentic works without it, and since
+// Claude Code gained native cross-instance messaging it is wanted only for
+// persistent memory.
 func ensureClauder() bool {
-	return promptInstall("clauder", "clauder", false,
+	return promptInstall("clauder", "clauder (persistent memory)", false,
 		"curl -fsSL https://raw.githubusercontent.com/MaorBril/clauder/main/install.sh | sh",
 		"https://github.com/MaorBril/clauder")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,6 @@ tracking. Everything after -- is passed to claude verbatim.`,
 			Profile:      flagProfile,
 			ModelFlag:    flagModel,
 			InstanceName: flagName,
-			NoClauder:    flagNoClauder,
 			Passthrough:  flagPassthrough,
 			ClaudeArgs:   claudeArgs,
 		}, logger())
@@ -56,8 +55,11 @@ tracking. Everything after -- is passed to claude verbatim.`,
 func init() {
 	rootCmd.Flags().StringVarP(&flagProfile, "profile", "p", "", "profile from ~/.agentic/config.yaml")
 	rootCmd.Flags().StringVar(&flagModel, "model", "", "one-shot main-model alias override")
-	rootCmd.Flags().StringVar(&flagName, "name", "", "instance name (forwarded to clauder)")
-	rootCmd.Flags().BoolVar(&flagNoClauder, "no-clauder", false, "launch bare claude even if clauder is installed")
+	rootCmd.Flags().StringVar(&flagName, "name", "", "session name (forwarded to claude)")
+	rootCmd.Flags().BoolVar(&flagNoClauder, "no-clauder", false, "")
+	// Every session is a bare claude now, so there is no wrap layer to opt out
+	// of. Kept as an accepted no-op so existing aliases and scripts still run.
+	rootCmd.Flags().MarkDeprecated("no-clauder", "sessions always launch claude directly; this flag does nothing")
 	rootCmd.Flags().BoolVar(&flagPassthrough, "passthrough", false, "skip the router (subscription billing, no tracking)")
 	rootCmd.AddCommand(routerCmd, costCmd, modelsCmd, setupCmd, contextCmd, evalCmd)
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -151,7 +151,8 @@ var setupCmd = &cobra.Command{
 		}
 
 		if ensureClauder() {
-			fmt.Println("  sessions will launch via `clauder wrap` (cross-instance messaging + memory)")
+			fmt.Println("  clauder's persistent memory is available to sessions over its own MCP server")
+			fmt.Println("  (cross-instance messaging is native to Claude Code — nothing to configure)")
 		}
 
 		fmt.Println("\nDone. Start a session with: agentic")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -66,7 +66,10 @@ This updates agentic only — Claude Code updates itself independently.`,
 		printRestartReport(rel.TagName)
 
 		// Running sessions host the router in-process; the new binary only
-		// takes over when they restart. Tell them via clauder.
+		// takes over when they restart. Claude Code's native peer messaging
+		// is session-to-session only, with no CLI to reach it from out here,
+		// so we still notify through clauder — which registers instances from
+		// its MCP server and so sees sessions we no longer wrap.
 		msg := fmt.Sprintf("[agentic] agentic was updated to %s. If this session was launched via `agentic`, "+
 			"its router is still running the old version — please tell the user this session should be "+
 			"restarted (exit and re-run `agentic`) at a convenient moment to pick up the update.", rel.TagName)

--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,6 @@ case ":$PATH:" in
 esac
 
 prompt_install claude "claude CLI" https://claude.ai/install.sh bash
-prompt_install clauder clauder https://raw.githubusercontent.com/MaorBril/clauder/main/install.sh sh
+prompt_install clauder "clauder (persistent memory, optional)" https://raw.githubusercontent.com/MaorBril/clauder/main/install.sh sh
 
 echo "Next: agentic setup"

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -24,8 +24,7 @@ import (
 type Options struct {
 	Profile      string
 	ModelFlag    string // one-shot main-model override (alias)
-	InstanceName string // forwarded to clauder wrap
-	NoClauder    bool
+	InstanceName string // forwarded to claude as --name
 	Passthrough  bool
 	ClaudeArgs   []string
 }
@@ -151,19 +150,34 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 	return err
 }
 
-// buildChild prefers `clauder wrap` when available so cross-instance
-// messaging works; env vars pass through its PTY untouched.
+// autoApprovedTools is the tool allowlist every agentic session runs with.
+// It is the set `clauder wrap --slave` used to pass before agentic spawned
+// claude itself, kept identical so the launch path change is invisible.
+// Allowlisting mcp__clauder__* is inert when clauder is not installed.
+var autoApprovedTools = []string{
+	"Read", "Write", "Edit", "Glob", "Grep", "Bash(*)",
+	"WebFetch", "WebSearch", "mcp__clauder__*",
+}
+
+// buildChild spawns claude directly. Claude Code registers each session in
+// ~/.claude/sessions and opens a peer socket, so cross-instance messaging is
+// native and no longer needs `clauder wrap` in front of us; clauder's memory
+// tools arrive over its own MCP registration regardless of how we launch.
+//
+// Caller args go first because --allowedTools is variadic: it consumes args
+// until the next flag, so a trailing bare prompt lands after it as a tool
+// name and claude exits with "Input must be provided". Repeating the flag
+// per tool (rather than one comma-joined value) keeps a tool spec that
+// contains a comma from being split.
 func buildChild(opts Options) []string {
-	if !opts.NoClauder {
-		if _, err := exec.LookPath("clauder"); err == nil {
-			args := []string{"clauder", "wrap", "--slave"}
-			if opts.InstanceName != "" {
-				args = append(args, "--name", opts.InstanceName)
-			}
-			return append(append(args, "--"), opts.ClaudeArgs...)
-		}
+	args := append([]string{"claude"}, opts.ClaudeArgs...)
+	if opts.InstanceName != "" {
+		args = append(args, "--name", opts.InstanceName)
 	}
-	return append([]string{"claude"}, opts.ClaudeArgs...)
+	for _, tool := range autoApprovedTools {
+		args = append(args, "--allowedTools", tool)
+	}
+	return args
 }
 
 func recordSession(dataDir, id, profile string, start bool) {

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -1,0 +1,42 @@
+package launch
+
+import (
+	"slices"
+	"testing"
+)
+
+// Pinned rather than read from autoApprovedTools: this is the set that
+// `clauder wrap --slave` used to pass, and silently dropping an entry would
+// change every session's permission posture.
+var wantTools = []string{
+	"Read", "Write", "Edit", "Glob", "Grep", "Bash(*)",
+	"WebFetch", "WebSearch", "mcp__clauder__*",
+}
+
+// claude's --allowedTools is variadic — it consumes args until the next flag,
+// so a caller's bare prompt sitting after it is eaten as a tool name and
+// claude exits with "Input must be provided". Caller args have to come first.
+func TestBuildChild(t *testing.T) {
+	got := buildChild(Options{
+		InstanceName: "backend",
+		ClaudeArgs:   []string{"--resume", "fix the bug"},
+	})
+
+	want := []string{"claude", "--resume", "fix the bug", "--name", "backend"}
+	for _, tool := range wantTools {
+		want = append(want, "--allowedTools", tool)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("buildChild:\n got  %v\n want %v", got, want)
+	}
+}
+
+func TestBuildChildWithoutInstanceName(t *testing.T) {
+	got := buildChild(Options{})
+	if got[0] != "claude" {
+		t.Fatalf("child should be claude, got %q", got[0])
+	}
+	if slices.Contains(got, "--name") {
+		t.Errorf("no instance name should leave claude to derive one: %v", got)
+	}
+}


### PR DESCRIPTION
Replaces the `clauder wrap --slave` launch layer with a direct `claude` spawn, now that Claude Code has native cross-instance messaging.

## Why this works

Claude Code registers every session under `~/.claude/sessions/<pid>.json` and opens a peer socket:

```json
{"pid":42336,"cwd":"…/agentic","version":"2.1.224","peerProtocol":1,
 "messagingSocketPath":"/tmp/cc-socks/42336.sock","name":"agentic-e7","status":"busy"}
```

Sessions discover each other with `ListAgents` and talk with `SendMessage`; `claude agents --json` exposes the same roster to shell scripts. Cross-instance messaging was the reason agentic launched through `clauder wrap`, so the wrapper can go — one less subprocess and PTY hop.

**clauder is unaffected as a memory companion.** It registers its MCP server globally (`clauder: ~/.local/bin/clauder serve`), so `remember`/`recall`/`get_context` reach sessions no matter how they were started. Verified directly: a bare `claude` launched from a shell — no agentic, no wrap — has `mcp__clauder__*` connected.

## Behavior is preserved deliberately

I probed what `wrap --slave` was actually passing:

```
--allowedTools Read Write Edit Glob Grep Bash(*) WebFetch WebSearch mcp__clauder__*
```

agentic now passes exactly that itself, so sessions keep the autonomous tool set they have today. Caller args go **before** the allowlist because `--allowedTools` is variadic on claude's side and would otherwise swallow a trailing bare prompt as a tool name — the ordering wrap used, and now covered by a test.

`--name` is forwarded to claude, which has its own session naming (it shows in the prompt box, `/resume` picker, and the session registry).

## `agentic update` keeps its broadcast

Native peer messaging is session-to-session only — there is no `claude send <session> "msg"` CLI, and `/tmp/cc-socks/*.sock` is a private protocol I would not build on. `clauder.Broadcast` stays because clauder registers its instance from the MCP server, not from `wrap`, so it still sees sessions we no longer wrap. Confirmed with `clauder instances` against a non-wrapped session. `printRestartReport` remains the primary signal.

## Deprecation

`--no-clauder` is now an accepted no-op with a deprecation warning and is hidden from `--help`: every session is a bare claude, so there is no wrap layer to opt out of. Existing aliases and scripts keep working.

## Rollout note

Peer messaging only lights up on Claude Code ≥2.1.224. On this machine 7 of 8 running sessions were on 2.1.220–2.1.223 and `ListAgents` returned "No reachable agents" — the feature appears as sessions restart onto a current build. Nothing in this PR depends on peers existing; it degrades to a normal solo session.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- New `internal/launch/launch_test.go` covers the direct spawn, `--name` forwarding, the allowlist, and the caller-args-first ordering
- Confirmed `claude` parses the exact argv shape agentic now builds
- Confirmed `--no-clauder` still parses and warns

🤖 Generated with [Claude Code](https://claude.com/claude-code)