### PR TITLE
Add `agentic peers` to resolve approximate session names

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,30 @@ Every model you've configured becomes selectable by name — `subagent_type: "ag
 
 When your aliases change, the next `agentic` launch offers to refresh them (once — decline and it stays quiet until the aliases change again; `AGENTIC_NO_AGENT_SYNC=1` opts out entirely). Only files prefixed `agentic-` are ever written or removed, so your own subagents are never touched.
 
+## Finding another session
+
+Claude Code sessions can message each other, but addressing one is awkward: session names are auto-derived from whatever that session is doing (`daily-case-runtime`), so the name you'd actually say is the project directory — and `ListAgents`, the only thing that can mint the `[ref]` a cross-session `SendMessage` needs, doesn't show directories.
+
+`agentic peers` closes that gap by matching on both:
+
+```
+$ agentic peers labs-service-secondlife-be
+Best match for "labs-service-secondlife-be":
+  daily-case-runtime             busy  ~/code/secondlife/labs-service         started 12h ago
+
+To message it: call ListAgents for its [ref], then SendMessage to
+"daily-case-runtime [ref]" — the bare name works after first contact.
+```
+
+With no argument it lists every session you can reach. Sessions on a build older than Claude Code 2.1.224 register no socket and are unreachable until restarted — they're reported as a count rather than silently omitted. When a query matches several sessions equally well, it says so instead of picking one.
+
+`agentic setup` writes this workflow into `~/.claude/CLAUDE.md`, between `<!-- agentic:peers:start -->` markers, so every session — agentic-launched or plain `claude` — knows to resolve names this way. Re-running setup refreshes that block and leaves the rest of the file alone.
+
 ## Works with clauder
 
 agentic spawns `claude` directly and grants each session an auto-approved tool set for autonomous operation (`Read Write Edit Glob Grep Bash(*) WebFetch WebSearch mcp__clauder__*`). `--name` becomes claude's own session name.
 
-Cross-instance messaging is native to Claude Code — sessions register under `~/.claude/sessions` and reach each other over a peer socket — so agentic no longer launches through `clauder wrap`. [clauder](https://github.com/MaorBril/clauder) remains a useful companion for **persistent memory**, which it provides over its own MCP server registration and therefore works no matter how the session was started. The two tools are independent; each works without the other.
+Cross-instance messaging is native to Claude Code — sessions register under `~/.claude/sessions` and reach each other over a peer socket — so agentic no longer launches through `clauder wrap`. See [Finding another session](#finding-another-session) for addressing them. [clauder](https://github.com/MaorBril/clauder) remains a useful companion for **persistent memory**, which it provides over its own MCP server registration and therefore works no matter how the session was started. The two tools are independent; each works without the other.
 
 `--no-clauder` is accepted but deprecated: every session is a bare claude now, so there is no wrap layer to opt out of.
 
@@ -247,7 +266,8 @@ Cross-instance messaging is native to Claude Code — sessions register under `~
 | Command | What it does |
 |---|---|
 | `agentic [-p profile] [--model alias] [-- args]` | launch Claude Code (args after `--` go to claude) |
-| `agentic setup` | first-run config, token, statusline registration |
+| `agentic setup` | first-run config, token, statusline + peer-guidance registration |
+| `agentic peers [name]` | find another Claude Code session to message |
 | `agentic cost [--week\|--month] [--by model\|profile\|session]` | spend report |
 | `agentic context [session-id]` | context-fullness trajectory (true vs reported tokens) |
 | `agentic eval run/report` | paired model evaluation and artifact report |

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/maorbril/agentic/internal/peers"
+)
+
+var peersCmd = &cobra.Command{
+	Use:   "peers [approximate name]",
+	Short: "Find another Claude Code session to message",
+	Long: `Resolve the approximate name people use for a session ("the labs-service
+one") to a specific session, matching on both session name and working
+directory. With no argument, lists every session that can receive a message.
+
+Sending is done from inside a session: call ListAgents for the [ref], then
+SendMessage to "<name> [ref]".`,
+	Args:          cobra.ArbitraryArgs,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		all, err := peers.Load(filepath.Join(home, ".claude", "sessions"))
+		if err != nil {
+			return err
+		}
+
+		selfID := os.Getenv("CLAUDE_CODE_SESSION_ID")
+		var live []peers.Session
+		var self *peers.Session
+		var stale int
+		for _, s := range all {
+			if !pidAlive(s.PID) {
+				continue
+			}
+			if s.SessionID == selfID {
+				self = &s
+				continue
+			}
+			if !s.Reachable() {
+				stale++
+				continue
+			}
+			live = append(live, s)
+		}
+
+		// Printed last on every path, including the no-match error: unreachable
+		// sessions are usually the reason a lookup came up empty.
+		defer printStale(stale)
+
+		if len(live) == 0 {
+			fmt.Println("No other session can receive a message right now.")
+			return nil
+		}
+
+		query := strings.Join(args, " ")
+		ranked := peers.Match(live, query)
+		if len(ranked) == 0 {
+			// Being asked to message the session you already are is a plausible
+			// mix-up; saying so beats "no match" and a retry loop.
+			if self != nil && len(peers.Match([]peers.Session{*self}, query)) > 0 {
+				return fmt.Errorf("%q is this session (%s) — nothing to message", query, self.Name)
+			}
+			return fmt.Errorf("no reachable session matches %q — run `agentic peers` to see them all", query)
+		}
+
+		if query == "" {
+			fmt.Printf("Sessions you can message (%d):\n", len(ranked))
+			for _, r := range ranked {
+				fmt.Println(line(r.Session, home))
+			}
+			return nil
+		}
+
+		if peers.Ambiguous(ranked) {
+			fmt.Printf("%q matches these equally well — ask which one is meant, don't guess:\n", query)
+			for _, r := range ranked {
+				if r.Score < ranked[0].Score {
+					break
+				}
+				fmt.Println(line(r.Session, home))
+			}
+			return nil
+		}
+
+		fmt.Printf("Best match for %q:\n%s\n", query, line(ranked[0].Session, home))
+		if len(ranked) > 1 {
+			fmt.Println("\nAlso matched, less closely:")
+			for _, r := range ranked[1:] {
+				fmt.Println(line(r.Session, home))
+			}
+		}
+		fmt.Printf("\nTo message it: call ListAgents for its [ref], then SendMessage to\n"+
+			"%q — the bare name works after first contact.\n", ranked[0].Name+" [ref]")
+		return nil
+	},
+}
+
+func line(s peers.Session, home string) string {
+	return fmt.Sprintf("  %-30s %-5s %-38s started %s",
+		s.Name, s.Status, tildePath(s.Dir, home), humanAge(s.Started))
+}
+
+func printStale(n int) {
+	if n == 0 {
+		return
+	}
+	fmt.Printf("\n· %d other session(s) predate native messaging and cannot be reached —\n"+
+		"  restart them (exit and relaunch) to make them addressable.\n", n)
+}
+
+func tildePath(dir, home string) string {
+	if home != "" && strings.HasPrefix(dir, home) {
+		return "~" + dir[len(home):]
+	}
+	return dir
+}
+
+func init() {
+	rootCmd.AddCommand(peersCmd)
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/maorbril/agentic/internal/config"
 	"github.com/maorbril/agentic/internal/launch"
+	"github.com/maorbril/agentic/internal/peers"
 )
 
 // registerStatusline merges a statusLine entry into ~/.claude/settings.json
@@ -48,6 +49,31 @@ func registerStatusline() error {
 		return err
 	}
 	fmt.Println("✓ registered agentic statusline in ~/.claude/settings.json")
+	return nil
+}
+
+// registerPeerGuidance teaches every session — agentic-launched or not — how
+// to resolve an approximate session name via `agentic peers`. It lives in
+// ~/.claude/CLAUDE.md between markers, so re-running setup refreshes the block
+// without touching anything else in the file.
+func registerPeerGuidance() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".claude", "CLAUDE.md")
+	action, err := peers.InstallGuidance(path)
+	if err != nil {
+		return err
+	}
+	switch action {
+	case peers.Created:
+		fmt.Println("✓ wrote peer-resolution guidance to ~/.claude/CLAUDE.md")
+	case peers.Updated:
+		fmt.Println("✓ refreshed peer-resolution guidance in ~/.claude/CLAUDE.md")
+	default:
+		fmt.Println("✓ peer-resolution guidance already current in ~/.claude/CLAUDE.md")
+	}
 	return nil
 }
 
@@ -148,6 +174,10 @@ var setupCmd = &cobra.Command{
 
 		if err := registerStatusline(); err != nil {
 			fmt.Printf("⚠ could not register statusline: %v\n", err)
+		}
+
+		if err := registerPeerGuidance(); err != nil {
+			fmt.Printf("⚠ could not write peer guidance: %v\n", err)
 		}
 
 		if ensureClauder() {

--- a/internal/peers/guidance.go
+++ b/internal/peers/guidance.go
@@ -1,0 +1,83 @@
+package peers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	guidanceStart = "<!-- agentic:peers:start -->"
+	guidanceEnd   = "<!-- agentic:peers:end -->"
+)
+
+// Guidance tells a session how to turn an approximate name into a specific
+// peer. It lands in ~/.claude/CLAUDE.md so plain `claude` sessions get it too,
+// not just agentic-launched ones.
+const Guidance = `## Talking to other Claude sessions
+
+When asked to work with another session by an approximate name — "work with
+labs-service-secondlife-be", "ask the labs-ui session" — resolve it yourself
+rather than asking which session was meant. Session names are auto-derived from
+whatever that session is doing, so the name a user says is usually the project
+directory, and ListAgents does not show directories.
+
+1. Run ` + "`agentic peers <approximate name>`" + ` — it matches on both session name and
+   working directory, and lists only sessions that can actually receive a
+   message.
+2. Call ListAgents to get the ` + "`[ref]`" + ` for the name it returned.
+3. SendMessage with ` + "`to: \"<name> [ref]\"`" + ` on first contact. The bare name is
+   rejected the first time and works from then on.
+4. To reply to an incoming message, copy its ` + "`from=`" + ` value verbatim as ` + "`to`" + `.
+
+If several sessions match closely, ask which one — messaging the wrong project
+is worse than a question. If the session someone means is unreachable, say so
+instead of quietly picking a different one.`
+
+// Action reports what InstallGuidance did to the file.
+type Action int
+
+const (
+	Unchanged Action = iota
+	Created
+	Updated
+)
+
+// InstallGuidance writes Guidance into the CLAUDE.md at path, wrapped in
+// markers so re-running replaces the block instead of stacking copies. Text
+// outside the markers is left alone.
+func InstallGuidance(path string) (Action, error) {
+	block := guidanceStart + "\n" + Guidance + "\n" + guidanceEnd
+
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return Unchanged, err
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return Unchanged, err
+		}
+		return Created, os.WriteFile(path, []byte(block+"\n"), 0o644)
+	}
+
+	text := string(existing)
+	start := strings.Index(text, guidanceStart)
+	if start < 0 {
+		if strings.Contains(text, guidanceEnd) {
+			return Unchanged, fmt.Errorf("%s has a stray %s marker — remove it and re-run", path, guidanceEnd)
+		}
+		return Updated, os.WriteFile(path, []byte(strings.TrimRight(text, "\n")+"\n\n"+block+"\n"), 0o644)
+	}
+
+	end := strings.Index(text[start:], guidanceEnd)
+	if end < 0 {
+		return Unchanged, fmt.Errorf("%s has an unterminated agentic block — restore its %s marker and re-run", path, guidanceEnd)
+	}
+	end += start + len(guidanceEnd)
+
+	if text[start:end] == block {
+		return Unchanged, nil
+	}
+	return Updated, os.WriteFile(path, []byte(text[:start]+block+text[end:]), 0o644)
+}

--- a/internal/peers/peers.go
+++ b/internal/peers/peers.go
@@ -1,0 +1,128 @@
+// Package peers reads Claude Code's session registry and resolves the
+// approximate names people use for their sessions ("the labs-service one")
+// to a specific session.
+//
+// Session names are auto-derived from whatever the session is working on, so
+// the name a user says is usually the project directory rather than the
+// session name — and ListAgents, the only thing that can mint the [ref] a
+// cross-session SendMessage needs, does not expose directories. Matching has
+// to happen out here, against the registry, where both fields exist.
+package peers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Session struct {
+	PID       int
+	SessionID string
+	Name      string
+	Dir       string
+	Status    string
+	Version   string
+	Socket    string // messagingSocketPath — empty on builds without native messaging
+	Started   time.Time
+}
+
+// Reachable reports whether the session can receive a message at all. Builds
+// before Claude Code 2.1.224 register no socket and stay invisible to
+// ListAgents until they restart.
+func (s Session) Reachable() bool { return s.Socket != "" }
+
+type Ranked struct {
+	Session
+	Score int
+}
+
+// Load parses every session record in dir, newest first. Unreadable or
+// malformed records are skipped rather than failing the whole listing — the
+// registry is written by another process and may be mid-write.
+func Load(dir string) ([]Session, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return nil, err
+	}
+	var sessions []Session
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var raw struct {
+			PID       int    `json:"pid"`
+			SessionID string `json:"sessionId"`
+			Name      string `json:"name"`
+			Dir       string `json:"cwd"`
+			Status    string `json:"status"`
+			Version   string `json:"version"`
+			Socket    string `json:"messagingSocketPath"`
+			StartedAt int64  `json:"startedAt"`
+		}
+		if json.Unmarshal(data, &raw) != nil || raw.PID == 0 {
+			continue
+		}
+		sessions = append(sessions, Session{
+			PID:       raw.PID,
+			SessionID: raw.SessionID,
+			Name:      raw.Name,
+			Dir:       raw.Dir,
+			Status:    raw.Status,
+			Version:   raw.Version,
+			Socket:    raw.Socket,
+			Started:   time.UnixMilli(raw.StartedAt),
+		})
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].Started.After(sessions[j].Started)
+	})
+	return sessions, nil
+}
+
+// Match ranks sessions against an approximate name, scoring how many of the
+// query's words appear in the session name or its directory. An exact name
+// hit outranks any amount of directory overlap. Sessions matching nothing are
+// dropped; an empty query returns everything unscored.
+func Match(sessions []Session, query string) []Ranked {
+	tokens := tokenize(query)
+	ranked := make([]Ranked, 0, len(sessions))
+	for _, s := range sessions {
+		if len(tokens) == 0 {
+			ranked = append(ranked, Ranked{Session: s})
+			continue
+		}
+		haystack := strings.ToLower(s.Name + " " + s.Dir)
+		score := 0
+		for _, tok := range tokens {
+			if strings.Contains(haystack, tok) {
+				score++
+			}
+		}
+		if score == 0 {
+			continue
+		}
+		if strings.EqualFold(strings.Join(tokens, "-"), s.Name) {
+			score += len(tokens) // exact name beats directory overlap
+		}
+		ranked = append(ranked, Ranked{Session: s, Score: score})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].Score > ranked[j].Score })
+	return ranked
+}
+
+// Ambiguous reports whether the top two matches are tied, meaning the query
+// does not actually pick one session.
+func Ambiguous(ranked []Ranked) bool {
+	return len(ranked) > 1 && ranked[0].Score == ranked[1].Score
+}
+
+func tokenize(query string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !('a' <= r && r <= 'z' || '0' <= r && r <= '9')
+	})
+	return fields
+}

--- a/internal/peers/peers_test.go
+++ b/internal/peers/peers_test.go
@@ -1,0 +1,138 @@
+package peers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRegistry(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	records := map[string]string{
+		"65686.json": `{"pid":65686,"sessionId":"709ae8bc","name":"daily-case-runtime",
+			"cwd":"/Users/m/code/secondlife/labs-service","status":"busy","version":"2.1.226",
+			"messagingSocketPath":"/tmp/cc-socks/65686.sock","startedAt":1786066338384}`,
+		"64257.json": `{"pid":64257,"sessionId":"bc748548","name":"daily-puzzle-frontend-launch",
+			"cwd":"/Users/m/code/secondlife/labs-ui","status":"idle","version":"2.1.226",
+			"messagingSocketPath":"/tmp/cc-socks/64257.sock","startedAt":1786066297180}`,
+		"71949.json": `{"pid":71949,"sessionId":"fe460cf6","name":"labs-service-e4",
+			"cwd":"/Users/m/code/labs-service","status":"idle","version":"2.1.223",
+			"startedAt":1786057168833}`,
+		"garbage.json": `{not json at all`,
+	}
+	for name, body := range records {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestLoadSkipsMalformedAndSortsNewestFirst(t *testing.T) {
+	got, err := Load(writeRegistry(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 parseable sessions, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "daily-case-runtime" {
+		t.Errorf("newest session should sort first, got %q", got[0].Name)
+	}
+}
+
+func TestReachabilityTracksMessagingSocket(t *testing.T) {
+	sessions, _ := Load(writeRegistry(t))
+	for _, s := range sessions {
+		// labs-service-e4 is on 2.1.223 and registers no socket.
+		if want := s.Name != "labs-service-e4"; s.Reachable() != want {
+			t.Errorf("%s: Reachable()=%v, want %v", s.Name, s.Reachable(), want)
+		}
+	}
+}
+
+// The name a user says is usually the directory: "labs-service-secondlife-be"
+// matches no session name, only a path.
+func TestMatchResolvesDirectoryPhrasing(t *testing.T) {
+	sessions, _ := Load(writeRegistry(t))
+	ranked := Match(sessions, "labs-service-secondlife-be")
+	if len(ranked) == 0 {
+		t.Fatal("no match for a directory-shaped query")
+	}
+	if ranked[0].Name != "daily-case-runtime" {
+		t.Errorf("want daily-case-runtime, got %q (%+v)", ranked[0].Name, ranked)
+	}
+	if Ambiguous(ranked) {
+		t.Errorf("labs-service should outrank labs-ui, got %+v", ranked)
+	}
+}
+
+func TestMatchPrefersExactNameOverDirectoryOverlap(t *testing.T) {
+	sessions, _ := Load(writeRegistry(t))
+	ranked := Match(sessions, "labs-service-e4")
+	if ranked[0].Name != "labs-service-e4" {
+		t.Errorf("exact name should win, got %q", ranked[0].Name)
+	}
+}
+
+func TestMatchDropsNonMatchesAndKeepsAllOnEmptyQuery(t *testing.T) {
+	sessions, _ := Load(writeRegistry(t))
+	if got := Match(sessions, "totally-unrelated"); len(got) != 0 {
+		t.Errorf("want no matches, got %+v", got)
+	}
+	if got := Match(sessions, ""); len(got) != len(sessions) {
+		t.Errorf("empty query should return everything, got %d", len(got))
+	}
+}
+
+func TestInstallGuidanceIsIdempotentAndPreservesOtherText(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+
+	if action, err := InstallGuidance(path); err != nil || action != Created {
+		t.Fatalf("first install: action=%v err=%v", action, err)
+	}
+	if action, err := InstallGuidance(path); err != nil || action != Unchanged {
+		t.Fatalf("re-install should be a no-op: action=%v err=%v", action, err)
+	}
+
+	// Someone's own notes around the block must survive a refresh.
+	body, _ := os.ReadFile(path)
+	if err := os.WriteFile(path, append([]byte("# My notes\n\nkeep me\n\n"), body...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if action, err := InstallGuidance(path); err != nil || action != Unchanged {
+		t.Fatalf("block unchanged despite surrounding text: action=%v err=%v", action, err)
+	}
+
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "keep me") {
+		t.Error("surrounding text was clobbered")
+	}
+	if n := strings.Count(string(got), guidanceStart); n != 1 {
+		t.Errorf("want exactly one guidance block, got %d", n)
+	}
+}
+
+func TestInstallGuidanceAppendsToExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	os.WriteFile(path, []byte("# Existing\n\nmy rules\n"), 0o644)
+
+	if action, err := InstallGuidance(path); err != nil || action != Updated {
+		t.Fatalf("append: action=%v err=%v", action, err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.Contains(string(got), "my rules") || !strings.Contains(string(got), guidanceEnd) {
+		t.Errorf("append lost content or marker:\n%s", got)
+	}
+}
+
+func TestInstallGuidanceRefusesToManglePartialMarkers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CLAUDE.md")
+	os.WriteFile(path, []byte(guidanceStart+"\nhalf a block\n"), 0o644)
+
+	if _, err := InstallGuidance(path); err == nil {
+		t.Error("want an error on an unterminated block, got nil")
+	}
+}


### PR DESCRIPTION
Follow-up to #12. Native cross-session messaging works, but *addressing* a session is the part that doesn't — this closes that gap.

## The problem

Session names are auto-derived from whatever the session is doing, so they don't match how anyone refers to them:

```
daily-case-runtime             ~/code/secondlife/labs-service   ← "the labs-service one"
daily-puzzle-frontend-launch   ~/code/secondlife/labs-ui
flavor-distill-e0              ~/code/flavor-distill
```

The name a person says is the **project directory**. `ListAgents` shows name, kind, status, and age — but not the directory — so it cannot resolve "labs-service-secondlife-be" on its own. And `ListAgents` is the only thing that can mint the `[ref]` a cross-session `SendMessage` requires on first contact.

## The command

```
$ agentic peers labs-service-secondlife-be
Best match for "labs-service-secondlife-be":
  daily-case-runtime             busy  ~/code/secondlife/labs-service         started 12h ago

Also matched, less closely:
  labs-service-a3                idle  ~/code/labs-service                    started 4m ago
  daily-puzzle-frontend-launch   idle  ~/code/secondlife/labs-ui              started 12h ago

To message it: call ListAgents for its [ref], then SendMessage to
"daily-case-runtime [ref]" — the bare name works after first contact.

· 2 other session(s) predate native messaging and cannot be reached —
  restart them (exit and relaunch) to make them addressable.
```

Three behaviors that matter more than the matching itself:

- **Unreachable sessions are counted, not hidden.** Sessions from before Claude Code 2.1.224 register no socket. Silently omitting them produces exactly the "messaging is broken" confusion that prompted this.
- **Ties are surfaced as ties.** `agentic peers labs-service` matches two sessions equally; it says so and declines to pick, rather than handing over a confident wrong answer.
- **It doesn't fake an address.** The `[ref]` is an opaque per-conversation handle minted by `ListAgents` — verified it is *not* the sessionId, nor any hash of the socket path, pid, or name. So `peers` resolves the name and hands off the exact two-step send instead of pretending to produce something it can't.

## Setup integration

`agentic setup` writes the resolution workflow into `~/.claude/CLAUDE.md` between `<!-- agentic:peers:start -->` markers, so plain `claude` sessions get it too. Re-running refreshes the block and leaves surrounding text untouched; a half-present marker pair is an error rather than a mangled file.

## Structure

`internal/peers` stays pure — parsing and matching only — so it's fully testable; `cmd/peers.go` owns liveness (reusing the existing `pidAlive`/`humanAge`) and printing. No duplicated process-check helper.

## Verification

- `gofmt`, `go build`, `go vet`, `go test ./...` clean
- 8 tests covering directory-shaped queries, exact-name precedence, malformed-record skipping, reachability, and guidance install idempotency (including preserving surrounding text and refusing partial markers)
- Exercised against the live registry: correct match for the real query, tie detection on `labs-service`, exit 1 with a useful message on no match
- Guidance installed through the real code path into `~/.claude/CLAUDE.md`: append on first run, no-op on second

🤖 Generated with [Claude Code](https://claude.com/claude-code)