### PR TITLE
openaibe: populate ErrMsg on 502s, add idle-stream deadline

### DIFF
--- a/internal/backend/openaibe/backend.go
+++ b/internal/backend/openaibe/backend.go
@@ -56,9 +56,9 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 		if ctx.Err() != nil {
 			return backend.Result{Status: 499, ErrType: "client_disconnect"}
 		}
-		anthropic.WriteError(w, 500, "api_error",
-			fmt.Sprintf("%s upstream: %v", call.Route.ProviderName, err))
-		return backend.Result{Status: 502, ErrType: "api_error"}
+		msg := fmt.Sprintf("%s upstream: %v", call.Route.ProviderName, err)
+		anthropic.WriteError(w, 500, "api_error", msg)
+		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	defer resp.Body.Close()
 
@@ -84,18 +84,21 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: reading upstream body: "+err.Error())
-		return backend.Result{Status: 502, ErrType: "api_error"}
+		msg := "agentic: reading upstream body: " + err.Error()
+		anthropic.WriteError(w, 500, "api_error", msg)
+		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	var parsed openai.ChatResponse
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: upstream body unparseable: "+err.Error())
-		return backend.Result{Status: 502, ErrType: "api_error"}
+		msg := "agentic: upstream body unparseable: " + err.Error()
+		anthropic.WriteError(w, 500, "api_error", msg)
+		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	out, err := TranslateResponse(&parsed, call.Envelope.Model)
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic translate: "+err.Error())
-		return backend.Result{Status: 502, ErrType: "api_error"}
+		msg := "agentic translate: " + err.Error()
+		anthropic.WriteError(w, 500, "api_error", msg)
+		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	trueUsage := out.Usage
 	out.Usage = tokens.ScaleUsage(trueUsage, scale)

--- a/internal/backend/openaibe/backend_test.go
+++ b/internal/backend/openaibe/backend_test.go
@@ -1,0 +1,78 @@
+package openaibe
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/backend"
+	"github.com/maorbril/agentic/internal/config"
+)
+
+const minimalReq = `{"model":"gpt","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`
+
+func callRoute(baseURL string) config.Resolved {
+	return config.Resolved{
+		Alias:        "gpt",
+		ProviderName: "openai",
+		Provider:     config.Provider{Type: "openai", BaseURL: baseURL},
+		Model:        config.Model{ID: "gpt-5.2"},
+	}
+}
+
+// TestMessagesUpstreamConnFailurePopulatesErrMsg covers the "transport
+// connect error" translation-failure path: a base URL nothing listens on, so
+// http.Client.Do itself fails. Before this fix Result.ErrMsg was left empty
+// on this path, so server.go's `res.ErrMsg != ""` gate silently dropped the
+// "upstream error" log line — the router-internal 502s were undiagnosable.
+func TestMessagesUpstreamConnFailurePopulatesErrMsg(t *testing.T) {
+	b := New()
+	route := callRoute("http://127.0.0.1:1") // port 1: nothing listens, connect fails fast
+	call := &backend.Call{
+		Raw:      []byte(minimalReq),
+		Envelope: anthropic.Envelope{Model: "gpt"},
+		Route:    route,
+	}
+	rec := httptest.NewRecorder()
+	res := b.Messages(context.Background(), call, rec)
+
+	if res.Status != 502 {
+		t.Fatalf("Status = %d, want 502", res.Status)
+	}
+	if res.ErrMsg == "" {
+		t.Error("ErrMsg is empty; upstream connect failures must be diagnosable in the router log")
+	}
+	if !strings.Contains(res.ErrMsg, "openai upstream") {
+		t.Errorf("ErrMsg = %q, want it to mention the provider", res.ErrMsg)
+	}
+}
+
+// TestMessagesUpstreamBadJSONPopulatesErrMsg covers the "upstream body
+// unparseable" translation-failure path: a 200 response whose body isn't
+// valid JSON. Same undiagnosable-502 class as the connect-failure case.
+func TestMessagesUpstreamBadJSONPopulatesErrMsg(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("not json"))
+	}))
+	defer upstream.Close()
+
+	b := New()
+	call := &backend.Call{
+		Raw:      []byte(minimalReq),
+		Envelope: anthropic.Envelope{Model: "gpt"},
+		Route:    callRoute(upstream.URL),
+	}
+	rec := httptest.NewRecorder()
+	res := b.Messages(context.Background(), call, rec)
+
+	if res.Status != 502 {
+		t.Fatalf("Status = %d, want 502", res.Status)
+	}
+	if res.ErrMsg == "" {
+		t.Error("ErrMsg is empty for an unparseable upstream body")
+	}
+}

--- a/internal/backend/openaibe/stream.go
+++ b/internal/backend/openaibe/stream.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -39,17 +40,29 @@ type streamState struct {
 	scale          float64         // context-scaling factor for client-facing usage
 	estInput       int64           // scaled input estimate for message_start (see startMessage)
 	keepAliveEvery time.Duration   // ping cadence while the upstream is quiet
+	idleTimeout    time.Duration   // give up if the upstream sends nothing at all for this long
 }
+
+// maxIdleStream is how long Run waits for upstream activity — a scanner
+// line, in either direction — before giving up. Distinct from
+// keepAliveEvery (which pings the *client*): a vLLM box can stall
+// byte-silently without closing the connection, and NewTransport's
+// ResponseHeaderTimeout only guards the initial headers, not an
+// already-established stream. Generous because slow reasoning models can
+// legitimately sit quiet for a minute before the first token.
+const maxIdleStream = 5 * time.Minute
 
 func newStreamState(sse *anthropic.SSEWriter, alias string) *streamState {
-	return &streamState{sse: sse, alias: alias, openaiToolIx: -1, scale: 1, keepAliveEvery: 15 * time.Second}
+	return &streamState{sse: sse, alias: alias, openaiToolIx: -1, scale: 1,
+		keepAliveEvery: 15 * time.Second, idleTimeout: maxIdleStream}
 }
 
-// Run consumes the upstream SSE body until EOF, [DONE], or ctx cancellation,
-// returning final usage. A mid-stream upstream error is forwarded as an
-// Anthropic error event (Claude Code retries on it). While the upstream is
-// quiet — slow reasoning models can sit for a minute before the first token —
-// pings keep the client from timing out on a byte-silent connection.
+// Run consumes the upstream SSE body until EOF, [DONE], ctx cancellation, or
+// idleTimeout of silence — returning final usage. A mid-stream upstream
+// error is forwarded as an Anthropic error event (Claude Code retries on
+// it). While the upstream is quiet — slow reasoning models can sit for a
+// minute before the first token — pings keep the client from timing out on
+// a byte-silent connection.
 func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage, string) {
 	lines := make(chan []byte)
 	scanErr := make(chan error, 1)
@@ -73,6 +86,8 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 
 	keepAlive := time.NewTicker(s.keepAliveEvery)
 	defer keepAlive.Stop()
+	idle := time.NewTimer(s.idleTimeout)
+	defer idle.Stop()
 
 	for {
 		select {
@@ -80,6 +95,14 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 			// Client hung up or the turn was cancelled; the transport closes
 			// the upstream body for us, so just stop translating.
 			return s.usage, "client_disconnect"
+		case <-idle.C:
+			// Upstream has produced nothing — not even scanner noise — for
+			// idleTimeout. Without this the select loop above waits on
+			// ctx.Done() forever: a stalled vLLM box that never closes the
+			// connection hangs the request indefinitely (the reported "stuck,
+			// needs a manual interrupt" symptom).
+			s.sse.ErrorEvent("api_error", fmt.Sprintf("upstream stream: no data for %s, giving up", s.idleTimeout))
+			return s.usage, "api_error"
 		case <-keepAlive.C:
 			s.ping()
 		case err := <-scanErr:
@@ -89,6 +112,10 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 			}
 			return s.usage, s.finalize()
 		case line := <-lines:
+			if !idle.Stop() {
+				<-idle.C
+			}
+			idle.Reset(s.idleTimeout)
 			data, ok := bytes.CutPrefix(line, []byte("data: "))
 			if !ok {
 				continue

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -283,6 +283,70 @@ func TestStreamCancellation(t *testing.T) {
 	}
 }
 
+func TestStreamIdleTimeout(t *testing.T) {
+	// A stalled upstream that never sends a byte and never closes the
+	// connection (the reported "stuck, needs a manual interrupt" symptom —
+	// no scanner EOF, no ctx cancellation) must still give up once idleTimeout
+	// elapses, rather than hang forever on ctx.Done().
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	rec := httptest.NewRecorder()
+	state := newStreamState(anthropic.NewSSEWriter(rec), "gpt")
+	state.keepAliveEvery = time.Hour // keep-alives shouldn't be what ends this
+	state.idleTimeout = 20 * time.Millisecond
+
+	done := make(chan string, 1)
+	go func() {
+		_, errType := state.Run(context.Background(), pr)
+		done <- errType
+	}()
+	select {
+	case errType := <-done:
+		if errType != "api_error" {
+			t.Errorf("errType = %q, want api_error", errType)
+		}
+		if !strings.Contains(rec.Body.String(), "no data for") {
+			t.Errorf("expected idle-timeout error event, got:\n%s", rec.Body.String())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after idleTimeout")
+	}
+}
+
+func TestStreamIdleTimeoutResetsOnActivity(t *testing.T) {
+	// Any scanner activity — including provider noise that isn't a usable
+	// chunk — must reset the idle clock, so a slow-but-alive upstream isn't
+	// mistaken for a stalled one.
+	pr, pw := io.Pipe()
+	rec := httptest.NewRecorder()
+	state := newStreamState(anthropic.NewSSEWriter(rec), "gpt")
+	state.keepAliveEvery = time.Hour
+	state.idleTimeout = 60 * time.Millisecond
+
+	done := make(chan string, 1)
+	go func() {
+		_, errType := state.Run(context.Background(), pr)
+		done <- errType
+	}()
+	// Trickle blank/noise lines slower than one write per idleTimeout but
+	// well within it, for longer than idleTimeout's total span.
+	for i := 0; i < 4; i++ {
+		time.Sleep(25 * time.Millisecond)
+		io.WriteString(pw, ": keep-alive noise\n\n")
+	}
+	io.WriteString(pw, "data: {\"id\":\"c7\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+	pw.Close()
+
+	select {
+	case errType := <-done:
+		if errType != "" {
+			t.Errorf("errType = %q, want success (empty)", errType)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return")
+	}
+}
+
 func TestStreamEmptyAfterKeepAlive(t *testing.T) {
 	// Upstream that goes quiet long enough for a keep-alive ping to open the
 	// message, then EOFs with zero chunks: still an error, not an empty


### PR DESCRIPTION
## Summary
Two of the three fixes identified while diagnosing why non-Anthropic model delegation sometimes feels stuck and needs a manual interrupt to move forward.

- **Populate `ErrMsg` on translation-failure 502 paths.** `Backend.Messages` had four paths (upstream connect error, response body read, JSON unmarshal, response translate) that returned `502` with an empty `ErrMsg`. `server.go`'s usage-logging gate (`res.Status >= 400 && res.ErrMsg != ""`) only warns when `ErrMsg` is non-empty, so these router-internal 502s were completely invisible in `router.log` — previously the only way to notice one happened was spotting the bare status code in a usage row.
- **Add an idle-stream deadline to `streamState.Run`.** The select loop only exited on `ctx.Done()`, a scanner error, or `[DONE]`/EOF. A self-hosted vLLM box that stalls mid-stream without closing the connection hung the request indefinitely — `keepAliveEvery` only pings the *client*, it never checks the upstream is still alive. Added a 5-minute `idleTimeout` (generous, since slow-reasoning models can legitimately sit quiet before the first token) that resets on any scanner activity and fails cleanly with `api_error` otherwise.

## Not in this PR
- The size-guard config values (`context_window`/`max_request_bytes` for gpt-5.6-sol/glm52/grok) were applied directly to `~/.agentic/config.yaml`, not this repo — kept separate per earlier discussion.
- Whether `standard` tier should route to `sonnet` instead of `gpt-5.6-sol` is an `agentic eval` question, not a code change, and is pending separately.

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- New tests: `TestStreamIdleTimeout`, `TestStreamIdleTimeoutResetsOnActivity` (stream.go), `TestMessagesUpstreamConnFailurePopulatesErrMsg`, `TestMessagesUpstreamBadJSONPopulatesErrMsg` (new backend_test.go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)