### PR TITLE
Task-aware model routing for auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,54 @@ agentic routing set auto --classifier haiku \
     --deep opus --standard sonnet --light qwen
 ```
 
-`auto` now behaves like a model (`/model auto`, or `profiles: {model: auto}`). On each new user turn, the classifier reads the request and assigns a tier — planning and hard debugging go `deep`, ordinary coding goes `standard`, mechanical edits and verification go `light`. The decision sticks for the rest of the turn (tool results don't re-trigger it), so a task never flips models mid-flight. Classification failures fall back to `--default` (standard), and every decision is logged:
+`auto` now behaves like a model (`/model auto`, or `profiles: {model: auto}`). On each new user turn, the classifier reads the request and assigns a tier: planning and hard debugging go `deep`, ordinary coding goes `standard`, and mechanical edits and verification go `light`. The decision sticks for the rest of the turn, so tool results do not trigger another classification or flip models mid-flight. Classification failures fall back to `--default` (standard).
+
+Task overrides add a second routing dimension without another classifier request. They are useful when two tasks need similar capability but perform better on different models. The supported labels are `implementation`, `sql_data`, `debugging`, `code_review`, `architecture`, `security_review`, and `critical_review`:
+
+```yaml
+models:
+  opus:   {provider: anthropic, id: claude-opus-5}
+  fable:  {provider: anthropic, id: claude-fable-5}
+  grok:   {provider: xai,       id: grok-4.6, context_window: 500000}
+
+routing:
+  auto:
+    classifier: haiku
+    default: standard
+    tiers: {deep: opus, standard: sonnet, light: qwen}
+    tasks:
+      implementation: grok
+      sql_data: grok
+      debugging: grok
+      code_review: grok
+      architecture: fable
+      security_review: fable
+      critical_review: opus
+```
+
+Configure the same policy from the CLI with repeatable task flags; later `routing set` calls preserve existing task mappings unless a matching flag updates one:
+
+```bash
+agentic routing set auto --classifier haiku \
+    --deep opus --standard sonnet --light qwen \
+    --task implementation=grok --task sql_data=grok \
+    --task debugging=grok --task code_review=grok \
+    --task architecture=fable --task security_review=fable \
+    --task critical_review=opus
+agentic routing list
+```
+
+A recognized task mapping takes precedence over the selected tier. Unrecognized or unmatched work uses the tier normally. If the mapped model cannot hold the request, the router falls back to the smallest eligible capability tier. Pinned sessions (`pin_tiers` / `X-Agentic-Pin-Model`) bypass task and tier classification entirely. Task classification is a model-selection hint, not a security boundary; enforce sensitive-work policy separately.
+
+Every decision is logged, and task choices appear in the existing reason field:
 
 ```
 $ grep autoroute ~/.agentic/router.log
-... alias=auto tier=deep model=opus
-... alias=auto tier=light model=qwen
+... alias=auto tier=standard model=grok reason=task:implementation
+... alias=auto tier=deep model=fable reason=task:security_review
 ```
 
-`agentic cost --by model` then shows how spend actually distributed across tiers. Each classification costs one tiny request to the classifier model (~$0.0005 with haiku).
+`agentic cost --by model` then shows how spend actually distributed. Each turn uses one tiny tier-only or combined tier-and-task request to the classifier model (~$0.0005 with haiku). Because config parsing is strict, a config containing `tasks:` requires an agentic binary that supports task routing; older binaries reject the field instead of silently ignoring it.
 
 ## Auto Goal
 

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -107,11 +107,15 @@ func mergeTaskFlags(existing map[string]string, flags []string) (map[string]stri
 		label, model, ok := strings.Cut(f, "=")
 		label = strings.TrimSpace(label)
 		model = strings.TrimSpace(model)
-		if !ok || label == "" || model == "" {
+		if !ok || label == "" {
 			return nil, fmt.Errorf("--task must be label=model, got %q", f)
 		}
 		if !config.IsTaskLabel(label) {
 			return nil, fmt.Errorf("--task: unknown label %q (want one of: %s)", label, strings.Join(config.TaskLabels, ", "))
+		}
+		if model == "" {
+			delete(merged, label)
+			continue
 		}
 		merged[label] = model
 	}
@@ -185,7 +189,7 @@ func init() {
 	routingSetCmd.Flags().StringVar(&routeStandard, "standard", "", "model alias for ordinary coding/tool work")
 	routingSetCmd.Flags().StringVar(&routeLight, "light", "", "model alias for mechanical edits/verification")
 	routingSetCmd.Flags().StringArrayVar(&routeTasks, "task", nil,
-		"task→model override, repeatable: label=model (e.g. --task security_review=fable); "+
+		"task→model override, repeatable: label=model; use label= to remove (e.g. --task security_review=fable); "+
 			"labels: "+strings.Join(config.TaskLabels, ", "))
 	routingCmd.AddCommand(routingSetCmd, routingListCmd, routingRemoveCmd)
 	rootCmd.AddCommand(routingCmd)

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -17,6 +18,7 @@ var (
 	routeDeep       string
 	routeStandard   string
 	routeLight      string
+	routeTasks      []string
 )
 
 var routingCmd = &cobra.Command{
@@ -31,16 +33,35 @@ var routingSetCmd = &cobra.Command{
 dispatches it to a tier. Use it like any model: /model auto, or
 profiles: {model: auto}.`,
 	Example: `  agentic routing set auto --classifier haiku \
-      --deep opus --standard sonnet --light qwen`,
+      --deep opus --standard sonnet --light qwen \
+      --task security_review=fable --task critical_review=opus`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if routeClassifier == "" {
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		existing := cfg.Routing[args[0]]
+		classifier := routeClassifier
+		if classifier == "" {
+			classifier = existing.Classifier
+		}
+		if classifier == "" {
 			return fmt.Errorf("--classifier is required (a cheap model alias)")
 		}
 		tiers := map[string]string{"deep": routeDeep, "standard": routeStandard, "light": routeLight}
-		snippet := "classifier: " + routeClassifier + "\n"
-		if routeDefault != "" {
-			snippet += "default: " + routeDefault + "\n"
+		for tier, model := range existing.Tiers {
+			if tiers[tier] == "" {
+				tiers[tier] = model
+			}
+		}
+		defaultTier := routeDefault
+		if defaultTier == "" {
+			defaultTier = existing.Default
+		}
+		snippet := "classifier: " + classifier + "\n"
+		if defaultTier != "" {
+			snippet += "default: " + defaultTier + "\n"
 		}
 		snippet += "tiers:\n"
 		any := false
@@ -53,10 +74,48 @@ profiles: {model: auto}.`,
 		if !any {
 			return fmt.Errorf("at least one of --deep / --standard / --light is required")
 		}
+		tasks, err := mergeTaskFlags(existing.Tasks, routeTasks)
+		if err != nil {
+			return err
+		}
+		if len(tasks) > 0 {
+			labels := make([]string, 0, len(tasks))
+			for l := range tasks {
+				labels = append(labels, l)
+			}
+			sort.Strings(labels)
+			snippet += "tasks:\n"
+			for _, l := range labels {
+				snippet += fmt.Sprintf("  %s: %s\n", l, tasks[l])
+			}
+		}
 		return editConfig(func(doc *config.Doc) error {
 			return doc.SetSubtree("routing", args[0], snippet)
 		}, "routing "+args[0])
 	},
+}
+
+// mergeTaskFlags parses repeatable --task label=model flags and merges them
+// onto the alias's existing task mappings, so task-only updates preserve the
+// rest of the routing rule.
+func mergeTaskFlags(existing map[string]string, flags []string) (map[string]string, error) {
+	merged := map[string]string{}
+	for label, model := range existing {
+		merged[label] = model
+	}
+	for _, f := range flags {
+		label, model, ok := strings.Cut(f, "=")
+		label = strings.TrimSpace(label)
+		model = strings.TrimSpace(model)
+		if !ok || label == "" || model == "" {
+			return nil, fmt.Errorf("--task must be label=model, got %q", f)
+		}
+		if !config.IsTaskLabel(label) {
+			return nil, fmt.Errorf("--task: unknown label %q (want one of: %s)", label, strings.Join(config.TaskLabels, ", "))
+		}
+		merged[label] = model
+	}
+	return merged, nil
 }
 
 var routingListCmd = &cobra.Command{
@@ -72,7 +131,7 @@ var routingListCmd = &cobra.Command{
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
-		fmt.Fprintln(tw, "ALIAS\tCLASSIFIER\tDEEP\tSTANDARD\tLIGHT\tDEFAULT")
+		fmt.Fprintln(tw, "ALIAS\tCLASSIFIER\tDEEP\tSTANDARD\tLIGHT\tDEFAULT\tTASKS")
 		names := make([]string, 0, len(cfg.Routing))
 		for n := range cfg.Routing {
 			names = append(names, n)
@@ -80,12 +139,32 @@ var routingListCmd = &cobra.Command{
 		sort.Strings(names)
 		for _, n := range names {
 			r := cfg.Routing[n]
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", n, r.Classifier,
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", n, r.Classifier,
 				orDefault(r.Tiers["deep"], "—"), orDefault(r.Tiers["standard"], "—"),
-				orDefault(r.Tiers["light"], "—"), orDefault(r.Default, "standard"))
+				orDefault(r.Tiers["light"], "—"), orDefault(r.Default, "standard"),
+				formatTasks(r.Tasks))
 		}
 		return tw.Flush()
 	},
+}
+
+// formatTasks renders a routing rule's task mappings as a compact
+// comma-separated "label=model" list for `routing list`, sorted for
+// deterministic output. "—" when no tasks are configured.
+func formatTasks(tasks map[string]string) string {
+	if len(tasks) == 0 {
+		return "—"
+	}
+	labels := make([]string, 0, len(tasks))
+	for l := range tasks {
+		labels = append(labels, l)
+	}
+	sort.Strings(labels)
+	parts := make([]string, 0, len(labels))
+	for _, l := range labels {
+		parts = append(parts, l+"="+tasks[l])
+	}
+	return strings.Join(parts, ",")
 }
 
 var routingRemoveCmd = &cobra.Command{
@@ -105,6 +184,9 @@ func init() {
 	routingSetCmd.Flags().StringVar(&routeDeep, "deep", "", "model alias for planning/architecture/hard reasoning")
 	routingSetCmd.Flags().StringVar(&routeStandard, "standard", "", "model alias for ordinary coding/tool work")
 	routingSetCmd.Flags().StringVar(&routeLight, "light", "", "model alias for mechanical edits/verification")
+	routingSetCmd.Flags().StringArrayVar(&routeTasks, "task", nil,
+		"task→model override, repeatable: label=model (e.g. --task security_review=fable); "+
+			"labels: "+strings.Join(config.TaskLabels, ", "))
 	routingCmd.AddCommand(routingSetCmd, routingListCmd, routingRemoveCmd)
 	rootCmd.AddCommand(routingCmd)
 }

--- a/cmd/routing_test.go
+++ b/cmd/routing_test.go
@@ -1,0 +1,23 @@
+package cmd
+
+import "testing"
+
+func TestMergeTaskFlagsCanRemoveOverride(t *testing.T) {
+	existing := map[string]string{
+		"implementation":  "grok",
+		"security_review": "fable",
+	}
+	got, err := mergeTaskFlags(existing, []string{"security_review="})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["security_review"]; ok {
+		t.Errorf("security_review override was not removed: %v", got)
+	}
+	if got["implementation"] != "grok" {
+		t.Errorf("unrelated override changed: %v", got)
+	}
+	if existing["security_review"] != "fable" {
+		t.Errorf("input map was mutated: %v", existing)
+	}
+}

--- a/docs/context-scaling.md
+++ b/docs/context-scaling.md
@@ -85,10 +85,18 @@ Claude Code treats the 400 as a terminal error (no retry-spin), which is why
 it's used over 413/429. The guard is skipped for `count_tokens` and for
 models with an unknown budget.
 
+**Task overrides.** A task-aware rule classifies task and tier in the same
+request. A configured task model takes precedence over the tier target, but it
+must pass the same context-budget and request-byte checks. If it cannot hold the
+request, the router uses the smallest eligible capability tier instead of trying
+another task model. The chosen task and any tier remap remain sticky for tool
+results in that turn. Pinned sessions bypass both task and tier routing.
+
 Both behaviors are observable: the router logs `autoroute_size` (Debug) with
 the estimate, required tokens, excluded tiers, and the remap; `route_decisions`
-gains a `reason` column (`size:light→standard`, `size:sticky:light→standard`)
-visible via the statusline and `agentic context`.
+gains a `reason` column (`size:light→standard`, `size:sticky:light→standard`,
+`task:implementation`, or `task:sql_data:size-ineligible`) visible via the
+statusline and `agentic context`.
 
 **Request-body byte cap.** Separate from the token budget: some upstreams cap
 the raw request body size (e.g. an nginx `client_max_body_size`), and a body can

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,39 @@ type RouteRule struct {
 	Classifier string            `yaml:"classifier"` // model alias used to classify
 	Default    string            `yaml:"default"`    // tier when classification fails ("" = standard)
 	Tiers      map[string]string `yaml:"tiers"`      // deep/standard/light -> model alias
+	// Tasks optionally maps a fixed set of task labels (see TaskLabels) to a
+	// model alias that overrides the tier pick for that kind of work — e.g.
+	// routing security_review to a specific reviewer model regardless of
+	// which tier the request would otherwise land on. Absent/empty means
+	// exact tier-only behavior: no combined task classification happens, and
+	// routing is byte-for-byte identical to a rule with no Tasks at all.
+	Tasks map[string]string `yaml:"tasks"`
+}
+
+// TaskLabels is the fixed, closed set of task labels a task-aware routing
+// rule may map. Fixed (not user-extensible) because the classifier prompt
+// enumerates them by name and the allow-list parser validates classifier
+// output against exactly this set — fail-open (treat as "no task") for
+// anything else, never a dynamically-extended list.
+var TaskLabels = []string{
+	"implementation",
+	"sql_data",
+	"debugging",
+	"code_review",
+	"architecture",
+	"security_review",
+	"critical_review",
+}
+
+// IsTaskLabel reports whether s (expected already lowercased/trimmed) is one
+// of the fixed TaskLabels.
+func IsTaskLabel(s string) bool {
+	for _, l := range TaskLabels {
+		if l == s {
+			return true
+		}
+	}
+	return false
 }
 
 type Router struct {
@@ -283,6 +316,15 @@ func (c *Config) Validate() error {
 		if r.Default != "" {
 			if _, ok := r.Tiers[r.Default]; !ok {
 				return fmt.Errorf("config: routing %q default %q is not a tier", name, r.Default)
+			}
+		}
+		for label, alias := range r.Tasks {
+			if !IsTaskLabel(label) {
+				return fmt.Errorf("config: routing %q task %q is not a recognized label (want one of: %s)",
+					name, label, strings.Join(TaskLabels, ", "))
+			}
+			if _, ok := c.Models[alias]; !ok {
+				return fmt.Errorf("config: routing %q task %q references unknown model alias %q", name, label, alias)
 			}
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,6 +108,51 @@ profiles:
 	}
 }
 
+func TestTaskRoutingValidation(t *testing.T) {
+	base := `
+providers:
+  anthropic: {type: anthropic, base_url: https://api.anthropic.com}
+models:
+  haiku: {provider: anthropic, id: claude-haiku-4-5}
+  opus: {provider: anthropic, id: claude-opus-5}
+  grok: {provider: anthropic, id: grok-4.6}
+routing:
+  auto:
+    classifier: haiku
+    default: standard
+    tiers: {deep: opus, standard: opus, light: haiku}
+    tasks: {implementation: grok, critical_review: opus}
+`
+	cfg, err := Parse([]byte(base))
+	if err != nil {
+		t.Fatalf("valid task routing rejected: %v", err)
+	}
+	if cfg.Routing["auto"].Tasks["implementation"] != "grok" {
+		t.Fatalf("task mapping not parsed: %#v", cfg.Routing["auto"].Tasks)
+	}
+
+	cases := map[string]string{
+		"unknown task label": strings.Replace(base, "implementation: grok", "coding: grok", 1),
+		"unknown task alias": strings.Replace(base, "implementation: grok", "implementation: ghost", 1),
+	}
+	for name, yaml := range cases {
+		if _, err := Parse([]byte(yaml)); err == nil {
+			t.Errorf("%s: expected validation error", name)
+		}
+	}
+}
+
+func TestTaskLabelsAreRecognized(t *testing.T) {
+	for _, label := range TaskLabels {
+		if !IsTaskLabel(label) {
+			t.Errorf("TaskLabels contains unrecognized label %q", label)
+		}
+	}
+	if IsTaskLabel("coding") || IsTaskLabel("") {
+		t.Error("unknown task labels must be rejected")
+	}
+}
+
 func TestContextBudget(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -24,7 +24,11 @@ import (
 // doesn't flip models mid-flight.
 type autoRouter struct {
 	classify func(ctx context.Context, rule config.RouteRule, cfg *config.Config, summary string) (string, error)
-	log      *slog.Logger
+	// classifyTask is used instead of classify when the rule is task-aware
+	// (len(rule.Tasks) > 0): one combined request returns both tier and
+	// task, so task-aware routing never costs a second classifier call.
+	classifyTask func(ctx context.Context, rule config.RouteRule, cfg *config.Config, summary string) (tier, task string, err error)
+	log          *slog.Logger
 
 	mu    sync.Mutex
 	cache map[string]decision // key: session id (or user-text hash when unattributed)
@@ -33,7 +37,23 @@ type autoRouter struct {
 type decision struct {
 	userHash string
 	tier     string
-	at       time.Time
+	// task is the classified task label ("" when the rule isn't task-aware,
+	// classification didn't run this turn, or the classifier's answer
+	// wasn't a recognized label). Retained across sticky continuations
+	// alongside tier so a task override survives mid-turn tool_result
+	// round-trips the same way the tier does.
+	task string
+	at   time.Time
+}
+
+// resetCache clears sticky per-session decisions. Called on config reload
+// (Server.Reload) so a routing-rule edit — tiers, tasks, classifier —
+// applies to the very next request instead of being masked by a sticky
+// decision cached under the previous config.
+func (a *autoRouter) resetCache() {
+	a.mu.Lock()
+	a.cache = map[string]decision{}
+	a.mu.Unlock()
 }
 
 const classifierPrompt = `You route requests inside a coding agent to a model tier. Reply with exactly one word: deep, standard, or light.
@@ -48,7 +68,12 @@ Request to classify:
 // route picks the concrete model alias for a dynamically-routed request. The
 // returned reason is a free-text note for observability — non-empty when
 // size-aware routing remapped the classifier's choice (e.g.
-// "size:light→standard"); empty for a plain classifier decision.
+// "size:light→standard") and/or a task label was classified and applied
+// (e.g. "task:security_review"); empty for a plain classifier decision on a
+// rule with no Tasks configured. When rule.Tasks is empty this function's
+// behavior is byte-for-byte identical to before task-aware routing existed:
+// the task branch below is only ever reached with task=="", which is a
+// documented no-op in applyTask.
 func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *config.Config, raw []byte, sessionID string) (alias, tier, reason string) {
 	fallback := rule.Default
 	if fallback == "" {
@@ -83,30 +108,36 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 	a.mu.Unlock()
 
 	// Continuations (tool results coming back) and retries of the same
-	// turn keep the tier that opened the turn.
+	// turn keep the tier (and task) that opened the turn.
 	if hasPrev && (!isNewTurn || prev.userHash == hash) {
 		if _, ok := rule.Tiers[prev.tier]; ok {
-			if fit.Eligible[prev.tier] {
-				return rule.Tiers[prev.tier], prev.tier, ""
+			tier = prev.tier
+			var sizeReason string
+			if !fit.Eligible[tier] {
+				// The sticky tier can't hold this (larger) continuation.
+				// Remap upward without re-classifying, and pin the cache so
+				// the rest of the turn stays on the remapped tier.
+				remapped := remapTier(cfg, rule, fit, tier)
+				a.logFit(rule, fit, tier, remapped, "sticky")
+				sizeReason = "size:sticky:" + tier + "→" + remapped
+				tier = remapped
 			}
-			// The sticky tier can't hold this (larger) continuation.
-			// Remap upward without re-classifying, and pin the cache so the
-			// rest of the turn stays on the remapped tier.
-			remapped := remapTier(cfg, rule, fit, prev.tier)
-			a.logFit(rule, fit, prev.tier, remapped, "sticky")
-			a.cacheDecision(key, hash, remapped)
-			return rule.Tiers[remapped], remapped, "size:sticky:" + prev.tier + "→" + remapped
+			var taskReason string
+			alias, taskReason = a.applyTask(cfg, rule, fit, tier, prev.task)
+			a.cacheDecision(key, hash, tier, prev.task)
+			return alias, tier, combineReason(taskReason, sizeReason)
 		}
 	}
 	if userText == "" {
 		return rule.Tiers[fallback], fallback, ""
 	}
 
-	// When size filtering has left exactly one viable tier, skip the
-	// classifier call — there's nothing to decide.
-	if t, ok := onlyEligibleTier(fit); ok {
+	// A tier-only rule can skip classification when size filtering leaves one
+	// viable tier. Task-aware rules still classify once because the task may
+	// select a different model that also fits the request.
+	if t, ok := onlyEligibleTier(fit); ok && len(rule.Tasks) == 0 {
 		a.logFit(rule, fit, "", t, "only")
-		a.cacheDecision(key, hash, t)
+		a.cacheDecision(key, hash, t, "")
 		return rule.Tiers[t], t, ""
 	}
 
@@ -114,32 +145,93 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 		len(req.Messages), len(req.Tools), truncate(userText, 2000))
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	tier, err = a.classify(cctx, rule, cfg, summary)
-	if err != nil || rule.Tiers[tier] == "" {
+
+	var task string
+	if len(rule.Tasks) > 0 {
+		// Task-aware rule: one combined classifier request returns both
+		// tier and task — never a second call.
+		tier, task, err = a.classifyTask(cctx, rule, cfg, summary)
+	} else {
+		tier, err = a.classify(cctx, rule, cfg, summary)
+	}
+	if err != nil {
+		tier = fallback
+		task = ""
+	} else if rule.Tiers[tier] == "" {
+		// A valid task remains useful even when the classifier's tier token is
+		// malformed: the concrete task target comes from trusted local config.
+		// With no valid task, this simply fails open to the configured tier.
 		tier = fallback
 	}
 
 	// The classifier has no notion of size; if it picked a tier the request
 	// won't fit, remap upward to the smallest tier that does.
+	var sizeReason string
 	if fit.Required > 0 && !fit.Eligible[tier] {
 		chosen := tier
 		tier = remapTier(cfg, rule, fit, chosen)
 		a.logFit(rule, fit, chosen, tier, "remap")
-		reason = "size:" + chosen + "→" + tier
+		sizeReason = "size:" + chosen + "→" + tier
 	}
 
-	a.cacheDecision(key, hash, tier)
-	return rule.Tiers[tier], tier, reason
+	var taskReason string
+	alias, taskReason = a.applyTask(cfg, rule, fit, tier, task)
+	reason = combineReason(taskReason, sizeReason)
+
+	a.cacheDecision(key, hash, tier, task)
+	return alias, tier, reason
 }
 
-// cacheDecision stores a tier decision under key, flushing the cache when it
-// exceeds 1000 entries.
-func (a *autoRouter) cacheDecision(key, hash, tier string) {
+// applyTask resolves a classified task label to its rule.Tasks-mapped model
+// alias, overriding the tier's own alias when the mapping exists and the
+// mapped model can hold the request (aliasFits, the same size-aware check
+// tiers use). When the task is empty (no task classified, or the rule isn't
+// task-aware), unmapped, or size-ineligible, it falls back to the tier's
+// alias — which by this point has already been remapped through the
+// eligible tiers by the caller, so a size-ineligible task target still
+// resolves to *some* capable model rather than an oversized one.
+//
+// task=="" is a pure no-op (returns tierAlias, ""): this is what keeps a
+// rule with no Tasks configured byte-for-byte identical to tier-only
+// routing, since task is never anything but "" in that case.
+func (a *autoRouter) applyTask(cfg *config.Config, rule config.RouteRule, fit fitDecision, tier, task string) (alias, reason string) {
+	tierAlias := rule.Tiers[tier]
+	if task == "" {
+		return tierAlias, ""
+	}
+	candidate, mapped := rule.Tasks[task]
+	if !mapped || candidate == "" {
+		return tierAlias, ""
+	}
+	if fit.Required == 0 || aliasFits(cfg, candidate, fit.Required, fit.BodyBytes) {
+		return candidate, "task:" + task
+	}
+	a.logFit(rule, fit, task, tier, "task-size-ineligible")
+	return tierAlias, "task:" + task + ":size-ineligible"
+}
+
+// combineReason joins non-empty routing-reason components ("task:...",
+// "size:...") for observability, task first since task selection is the
+// conceptually primary decision and size just describes whether the
+// underlying tier had to move.
+func combineReason(parts ...string) string {
+	var nonEmpty []string
+	for _, p := range parts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+	return strings.Join(nonEmpty, ";")
+}
+
+// cacheDecision stores a tier(+task) decision under key, flushing the cache
+// when it exceeds 1000 entries.
+func (a *autoRouter) cacheDecision(key, hash, tier, task string) {
 	a.mu.Lock()
 	if len(a.cache) > 1000 {
 		a.cache = map[string]decision{}
 	}
-	a.cache[key] = decision{userHash: hash, tier: tier, at: time.Now()}
+	a.cache[key] = decision{userHash: hash, tier: tier, task: task, at: time.Now()}
 	a.mu.Unlock()
 }
 

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -124,7 +124,14 @@ func (a *autoRouter) route(ctx context.Context, rule config.RouteRule, cfg *conf
 			}
 			var taskReason string
 			alias, taskReason = a.applyTask(cfg, rule, fit, tier, prev.task)
-			a.cacheDecision(key, hash, tier, prev.task)
+			// A tool-result continuation has no user text, so preserve the
+			// opening turn's hash. This keeps retries of the opening request
+			// sticky after the continuation has updated the cached tier.
+			cachedHash := hash
+			if !isNewTurn {
+				cachedHash = prev.userHash
+			}
+			a.cacheDecision(key, cachedHash, tier, prev.task)
 			return alias, tier, combineReason(taskReason, sizeReason)
 		}
 	}
@@ -304,7 +311,7 @@ func (s *Server) classifyViaBackend(ctx context.Context, rule config.RouteRule, 
 	for _, block := range resp.Content {
 		if block.Type == "text" {
 			word := strings.ToLower(strings.TrimSpace(block.Text))
-			word = strings.Trim(word, ".\"' \n")
+			word = strings.Trim(word, "`.\"' \n")
 			return word, nil
 		}
 	}

--- a/internal/router/autoroute_test.go
+++ b/internal/router/autoroute_test.go
@@ -68,6 +68,110 @@ func TestAutoRouteSticksWithinTurn(t *testing.T) {
 	}
 }
 
+func TestAutoRouteTaskOverride(t *testing.T) {
+	calls := 0
+	rule := testRule()
+	rule.Tasks = map[string]string{"implementation": "grok", "architecture": "fable"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		calls++
+		return "standard", "implementation", nil
+	}
+	alias, tier, reason := a.route(context.Background(), rule, nil, body(`{"role":"user","content":"implement the endpoint"}`), "tasks")
+	if alias != "grok" || tier != "standard" || reason != "task:implementation" || calls != 1 {
+		t.Errorf("alias=%s tier=%s reason=%q calls=%d", alias, tier, reason, calls)
+	}
+}
+
+func TestAutoRouteTaskSticksWithinTurn(t *testing.T) {
+	calls := 0
+	rule := testRule()
+	rule.Tasks = map[string]string{"architecture": "fable"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		calls++
+		return "deep", "architecture", nil
+	}
+	a.route(context.Background(), rule, nil, body(`{"role":"user","content":"design the service"}`), "sticky-task")
+	continuation := body(`{"role":"user","content":"design the service"},
+	  {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"read","input":{}}]},
+	  {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"data"}]}`)
+	alias, tier, reason := a.route(context.Background(), rule, nil, continuation, "sticky-task")
+	if alias != "fable" || tier != "deep" || reason != "task:architecture" || calls != 1 {
+		t.Errorf("alias=%s tier=%s reason=%q calls=%d", alias, tier, reason, calls)
+	}
+}
+
+func TestAutoRouteValidTaskWithInvalidTier(t *testing.T) {
+	calls := 0
+	rule := testRule()
+	rule.Tasks = map[string]string{"security_review": "fable"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		return "banana", "security_review", nil
+	}
+	alias, tier, reason := a.route(context.Background(), rule, nil, body(`{"role":"user","content":"review this auth flow"}`), "invalid-tier")
+	if alias != "fable" || tier != "standard" || reason != "task:security_review" {
+		t.Errorf("alias=%s tier=%s reason=%q", alias, tier, reason)
+	}
+}
+
+func TestAutoRouteTaskFailureDropsOverride(t *testing.T) {
+	calls := 0
+	rule := testRule()
+	rule.Tasks = map[string]string{"implementation": "grok"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		return "deep", "implementation", errors.New("classifier down")
+	}
+	alias, tier, reason := a.route(context.Background(), rule, nil, body(`{"role":"user","content":"implement it"}`), "task-failure")
+	if alias != "sonnet" || tier != "standard" || reason != "" {
+		t.Errorf("alias=%s tier=%s reason=%q", alias, tier, reason)
+	}
+}
+
+func TestAutoRouteTaskClassificationRunsWithOneEligibleTier(t *testing.T) {
+	calls := 0
+	rule := sizedRule()
+	rule.Tasks = map[string]string{"security_review": "opus"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		calls++
+		return "deep", "security_review", nil
+	}
+	huge := []byte(`{"model":"auto","max_tokens":100,"messages":[{"role":"user","content":"` + repeat("w ", 80000) + `"}]}`)
+	alias, tier, reason := a.route(context.Background(), rule, sizedCfg(), huge, "one-tier-task")
+	if alias != "opus" || tier != "deep" || reason != "task:security_review" || calls != 1 {
+		t.Errorf("alias=%s tier=%s reason=%q calls=%d", alias, tier, reason, calls)
+	}
+}
+
+func TestAutoRouteTaskSizeFallback(t *testing.T) {
+	calls := 0
+	rule := sizedRule()
+	rule.Tasks = map[string]string{"implementation": "qwen"}
+	a := newAuto("", nil, &calls)
+	a.classifyTask = func(context.Context, config.RouteRule, *config.Config, string) (string, string, error) {
+		return "standard", "implementation", nil
+	}
+	alias, tier, reason := a.route(context.Background(), rule, sizedCfg(), bigBody("implement "), "task-size")
+	if alias != "sonnet" || tier != "standard" || !contains(reason, "task:implementation:size-ineligible") {
+		t.Errorf("alias=%s tier=%s reason=%q", alias, tier, reason)
+	}
+}
+
+func TestAutoRouterResetCache(t *testing.T) {
+	calls := 0
+	a := newAuto("deep", nil, &calls)
+	request := body(`{"role":"user","content":"plan it"}`)
+	a.route(context.Background(), testRule(), nil, request, "reload")
+	a.resetCache()
+	a.route(context.Background(), testRule(), nil, request, "reload")
+	if calls != 2 {
+		t.Errorf("classifier calls=%d, want 2 after cache reset", calls)
+	}
+}
+
 func TestAutoRouteFallsBackOnFailure(t *testing.T) {
 	calls := 0
 	a := newAuto("", errors.New("classifier down"), &calls)

--- a/internal/router/autoroute_test.go
+++ b/internal/router/autoroute_test.go
@@ -160,6 +160,21 @@ func TestAutoRouteTaskSizeFallback(t *testing.T) {
 	}
 }
 
+func TestAutoRouteContinuationPreservesOpeningHash(t *testing.T) {
+	calls := 0
+	a := newAuto("deep", nil, &calls)
+	opening := body(`{"role":"user","content":"plan the migration"}`)
+	a.route(context.Background(), testRule(), nil, opening, "retry")
+	continuation := body(`{"role":"user","content":"plan the migration"},
+	  {"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"read","input":{}}]},
+	  {"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"data"}]}`)
+	a.route(context.Background(), testRule(), nil, continuation, "retry")
+	a.route(context.Background(), testRule(), nil, opening, "retry")
+	if calls != 1 {
+		t.Errorf("opening-turn retry reclassified after continuation: calls=%d", calls)
+	}
+}
+
 func TestAutoRouterResetCache(t *testing.T) {
 	calls := 0
 	a := newAuto("deep", nil, &calls)

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -45,7 +45,7 @@ func NewServer(cfg *config.Config, token, dataDir string, st *store.Store, logge
 	s.cfg.Store(cfg)
 	s.pricing.Store(pricing.Load(dataDir, cfg))
 	s.gate = budget.NewGate(cfg, st, logger)
-	s.auto = &autoRouter{classify: s.classifyViaBackend, cache: map[string]decision{}, log: logger}
+	s.auto = &autoRouter{classify: s.classifyViaBackend, classifyTask: s.classifyTaskViaBackend, cache: map[string]decision{}, log: logger}
 	s.goal = &goalRouter{classify: s.classifyGoalViaBackend}
 	return s
 }
@@ -60,6 +60,10 @@ func (s *Server) Reload() error {
 	s.cfg.Store(cfg)
 	s.pricing.Store(pricing.Load(s.dataDir, cfg))
 	s.gate.SetConfig(cfg)
+	// A routing-rule edit (tiers, tasks, classifier) must apply to the very
+	// next request, not be masked by a sticky decision cached under the
+	// previous config.
+	s.auto.resetCache()
 	return nil
 }
 

--- a/internal/router/size.go
+++ b/internal/router/size.go
@@ -108,9 +108,9 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 	}
 
 	est := tokens.Estimate(req)
-	// Shared output cap: the largest MaxOutput among tiers and task targets,
-	// conservative (bias toward over-reserving, which biases toward
-	// remapping up — safe).
+	// Shared output cap: the largest MaxOutput among capability tiers. Task
+	// targets are checked after classification and must not make unrelated tier
+	// targets ineligible merely because a specialist model supports more output.
 	maxCap := 0
 	updateCap := func(alias string) {
 		if m, ok := cfg.Models[alias]; ok && m.MaxOutput > maxCap {
@@ -118,9 +118,6 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 		}
 	}
 	for _, alias := range rule.Tiers {
-		updateCap(alias)
-	}
-	for _, alias := range rule.Tasks {
 		updateCap(alias)
 	}
 	reqMax := 0

--- a/internal/router/size.go
+++ b/internal/router/size.go
@@ -70,8 +70,17 @@ type fitDecision struct {
 
 // classifyTierFit computes which tiers can hold the request. A tier is eligible
 // only if it fits BOTH the token budget and the provider's request-byte cap
-// (where either is known). When no tier has any known limit, it returns every
-// tier eligible with Required==0 — the backward-compat fast path.
+// (where either is known). When no tier — nor any task-mapped alias, see
+// below — has any known limit, it returns every tier eligible with
+// Required==0 — the backward-compat fast path.
+//
+// Task-mapped aliases (rule.Tasks) are folded into the "is sizing active at
+// all" and "shared output cap" computations even though Eligible is keyed by
+// tier only: a task target's own eligibility is checked separately (see
+// aliasFits, used by autoRouter.applyTask) against the same fit.Required/
+// fit.BodyBytes, so a task-only budget (no tier declares one) still gets a
+// real Required estimate to check against instead of always reading as
+// "unknown budget, always eligible".
 func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.MessagesRequest, bodyBytes int64) fitDecision {
 	elig := map[string]bool{}
 	for t := range rule.Tiers {
@@ -80,7 +89,7 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 
 	anyTokenKnown := false
 	anyByteKnown := false
-	for _, alias := range rule.Tiers {
+	checkAlias := func(alias string) {
 		if tierBudget(cfg, alias) > 0 {
 			anyTokenKnown = true
 		}
@@ -88,18 +97,31 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 			anyByteKnown = true
 		}
 	}
+	for _, alias := range rule.Tiers {
+		checkAlias(alias)
+	}
+	for _, alias := range rule.Tasks {
+		checkAlias(alias)
+	}
 	if !anyTokenKnown && !anyByteKnown {
 		return fitDecision{Eligible: elig, BodyBytes: bodyBytes}
 	}
 
 	est := tokens.Estimate(req)
-	// Shared output cap: the largest MaxOutput among tiers, conservative (bias
-	// toward over-reserving, which biases toward remapping up — safe).
+	// Shared output cap: the largest MaxOutput among tiers and task targets,
+	// conservative (bias toward over-reserving, which biases toward
+	// remapping up — safe).
 	maxCap := 0
-	for _, alias := range rule.Tiers {
+	updateCap := func(alias string) {
 		if m, ok := cfg.Models[alias]; ok && m.MaxOutput > maxCap {
 			maxCap = m.MaxOutput
 		}
+	}
+	for _, alias := range rule.Tiers {
+		updateCap(alias)
+	}
+	for _, alias := range rule.Tasks {
+		updateCap(alias)
 	}
 	reqMax := 0
 	if req != nil {
@@ -109,13 +131,7 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 
 	var filtered []string
 	for tier, alias := range rule.Tiers {
-		fits := true
-		if b := tierBudget(cfg, alias); b > 0 && required > int64(b) {
-			fits = false
-		}
-		if mb := tierMaxRequestBytes(cfg, alias); mb > 0 && bodyBytes > int64(mb) {
-			fits = false
-		}
+		fits := aliasFits(cfg, alias, required, bodyBytes)
 		elig[tier] = fits
 		if !fits {
 			filtered = append(filtered, tier)
@@ -123,6 +139,20 @@ func classifyTierFit(cfg *config.Config, rule config.RouteRule, req *anthropic.M
 	}
 	sort.Strings(filtered)
 	return fitDecision{Eligible: elig, Required: required, EstInput: est, BodyBytes: bodyBytes, Filtered: filtered}
+}
+
+// aliasFits reports whether a model alias (a tier's target or a task's
+// target — anything resolvable via config) can hold a request needing
+// `required` input+output tokens and `bodyBytes` of raw body, considering
+// only limits that are actually known (0/unset never filters).
+func aliasFits(cfg *config.Config, alias string, required, bodyBytes int64) bool {
+	if b := tierBudget(cfg, alias); b > 0 && required > int64(b) {
+		return false
+	}
+	if mb := tierMaxRequestBytes(cfg, alias); mb > 0 && bodyBytes > int64(mb) {
+		return false
+	}
+	return true
 }
 
 // onlyEligibleTier returns the single eligible tier when exactly one remains,

--- a/internal/router/size_test.go
+++ b/internal/router/size_test.go
@@ -88,6 +88,22 @@ func TestClassifyTierFitFilters(t *testing.T) {
 	}
 }
 
+func TestTaskMaxOutputDoesNotInflateTierRequirement(t *testing.T) {
+	cfg := sizedCfg()
+	largeTask := cfg.Models["tiny"]
+	largeTask.MaxOutput = 100000
+	largeTask.ContextWindow = 200000
+	cfg.Models["large-task"] = largeTask
+	rule := config.RouteRule{
+		Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"},
+		Tasks: map[string]string{"implementation": "large-task"},
+	}
+	fit := classifyTierFit(cfg, rule, reqWith("hello"), 0)
+	if !fit.Eligible["light"] || fit.Required >= 8000 {
+		t.Errorf("task output cap inflated tier requirement: required=%d eligible=%v", fit.Required, fit.Eligible)
+	}
+}
+
 func TestRemapTierSmallestFitting(t *testing.T) {
 	cfg := sizedCfg()
 	rule := config.RouteRule{Tiers: map[string]string{"deep": "opus", "standard": "sonnet", "light": "qwen"}}

--- a/internal/router/tasks.go
+++ b/internal/router/tasks.go
@@ -57,9 +57,8 @@ func parseTaskLabel(s string) string {
 
 // classifyTaskViaBackend runs the combined tier+task classifier prompt
 // through the router's own backends. Unparseable or non-JSON classifier
-// output fails open: it returns ("", "", nil) rather than an error, so the
-// caller's existing tier-fallback path (empty tier -> rule.Default) handles
-// it exactly like a garbage plain-tier answer already does.
+// output returns an error; route() handles that error by failing open to the
+// configured tier and dropping the task override.
 func (s *Server) classifyTaskViaBackend(ctx context.Context, rule config.RouteRule, cfg *config.Config, summary string) (tier, task string, err error) {
 	resp, err := s.runClassifier(ctx, rule, cfg, taskClassifierPrompt+summary, 60)
 	if err != nil {
@@ -78,7 +77,9 @@ func (s *Server) classifyTaskViaBackend(ctx context.Context, rule config.RouteRu
 		text = strings.TrimSpace(text)
 		var d taskTierDecision
 		if err := json.Unmarshal([]byte(text), &d); err != nil {
-			return "", "", nil // fail open: no task/tier signal, not a hard error
+			// Return an error so route() still fails open to the configured tier,
+			// while retaining an observable classifier-failure signal for callers.
+			return "", "", fmt.Errorf("parse task classifier output: %w", err)
 		}
 		return strings.ToLower(strings.TrimSpace(d.Tier)), parseTaskLabel(d.Task), nil
 	}

--- a/internal/router/tasks.go
+++ b/internal/router/tasks.go
@@ -1,0 +1,86 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/maorbril/agentic/internal/config"
+)
+
+// taskClassifierPrompt asks the classifier for tier and task together in one
+// request — task-aware routing never issues a second classifier call.
+const taskClassifierPrompt = `You route requests inside a coding agent to a model tier and, when it clearly
+applies, a task label.
+
+Reply with ONLY a JSON object, no other text: {"tier": "deep|standard|light", "task": "<label or empty>"}
+
+Tiers:
+deep: planning, architecture, debugging hard problems, multi-step reasoning, ambiguous or high-stakes decisions
+standard: writing or modifying code, ordinary multi-tool tasks
+light: mechanical edits, renames, formatting, summaries, verifying provided output, short factual answers
+
+Task labels — use one only if it clearly applies, otherwise use "":
+implementation: writing new code or features
+sql_data: SQL, data pipelines, database schema/queries
+debugging: diagnosing or fixing a bug/failure
+code_review: reviewing a diff or PR for correctness/quality
+architecture: system design, planning, structural decisions
+security_review: assessing security implications or vulnerabilities
+critical_review: high-stakes sanity check of a decision or plan already made
+
+Request to classify:
+`
+
+// taskTierDecision is the classifier's combined answer for a task-aware
+// routing rule.
+type taskTierDecision struct {
+	Tier string `json:"tier"`
+	Task string `json:"task"`
+}
+
+// parseTaskLabel is the allow-list parser for classifier-provided task
+// labels: normalizes case/whitespace and validates against the fixed
+// config.TaskLabels set, failing open (returning "") for anything that
+// doesn't match exactly — including near-misses, synonyms, or the
+// classifier inventing its own label. Classifier output is untrusted free
+// text, not a contract, so "invalid" is a routing no-op, never an error.
+func parseTaskLabel(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.Trim(s, ".\"' \n")
+	if config.IsTaskLabel(s) {
+		return s
+	}
+	return ""
+}
+
+// classifyTaskViaBackend runs the combined tier+task classifier prompt
+// through the router's own backends. Unparseable or non-JSON classifier
+// output fails open: it returns ("", "", nil) rather than an error, so the
+// caller's existing tier-fallback path (empty tier -> rule.Default) handles
+// it exactly like a garbage plain-tier answer already does.
+func (s *Server) classifyTaskViaBackend(ctx context.Context, rule config.RouteRule, cfg *config.Config, summary string) (tier, task string, err error) {
+	resp, err := s.runClassifier(ctx, rule, cfg, taskClassifierPrompt+summary, 60)
+	if err != nil {
+		return "", "", err
+	}
+	for _, block := range resp.Content {
+		if block.Type != "text" {
+			continue
+		}
+		text := strings.TrimSpace(block.Text)
+		// Classifiers occasionally wrap the JSON in a code fence despite
+		// instructions; strip one if present before parsing.
+		text = strings.TrimPrefix(text, "```json")
+		text = strings.TrimPrefix(text, "```")
+		text = strings.TrimSuffix(text, "```")
+		text = strings.TrimSpace(text)
+		var d taskTierDecision
+		if err := json.Unmarshal([]byte(text), &d); err != nil {
+			return "", "", nil // fail open: no task/tier signal, not a hard error
+		}
+		return strings.ToLower(strings.TrimSpace(d.Tier)), parseTaskLabel(d.Task), nil
+	}
+	return "", "", fmt.Errorf("task classifier returned no text")
+}

--- a/internal/router/tasks_test.go
+++ b/internal/router/tasks_test.go
@@ -1,0 +1,36 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/maorbril/agentic/internal/config"
+)
+
+func TestParseTaskLabel(t *testing.T) {
+	for _, label := range config.TaskLabels {
+		if got := parseTaskLabel(" \"" + label + "\". "); got != label {
+			t.Errorf("parseTaskLabel(%q) = %q", label, got)
+		}
+	}
+	for _, input := range []string{"", "coding", "security", "implementation extra"} {
+		if got := parseTaskLabel(input); got != "" {
+			t.Errorf("parseTaskLabel(%q) = %q, want empty", input, got)
+		}
+	}
+}
+
+func TestTaskClassifierPromptUsesClosedLabels(t *testing.T) {
+	for _, label := range config.TaskLabels {
+		if !contains(taskClassifierPrompt, label+":") {
+			t.Errorf("task classifier prompt omits %q", label)
+		}
+	}
+}
+
+func TestClassifyTaskViaBackendMalformedJSONFailsOpen(t *testing.T) {
+	// Parsing behavior is covered through the route-level fail-open tests. Keep
+	// this assertion focused on the allow-list parser used for backend output.
+	if got := parseTaskLabel(`{"task":"implementation"}`); got != "" {
+		t.Fatalf("open-ended classifier text was accepted as a task: %q", got)
+	}
+}


### PR DESCRIPTION
## Why

`routing.auto` could only predict a capability tier — `deep` / `standard` / `light`. That collapses two independent questions into one: routine implementation and architecture work can need comparable context while benefiting from very different models. There was no way to say "send bounded coding work to Grok, but keep architecture and security review on a frontier Anthropic model."

## What

An optional `tasks:` map on routing rules, layered on top of the existing tier map:

```yaml
routing:
  auto:
    classifier: haiku
    tiers: {deep: opus, standard: gpt-5.6-sol, light: sonnet}
    tasks:
      implementation: grok
      sql_data: grok
      debugging: grok
      code_review: grok
      architecture: fable
      security_review: fable
      critical_review: opus
```

Labels are a closed enum in code (`config.TaskLabels`), so prompts, validation, config, and telemetry can't drift apart. Unknown labels and unknown model aliases are rejected at parse time.

The classifier returns tier and task in a single call, so task-aware routing adds no extra request or latency.

## Semantics

- A configured task override beats the tier target, but only if the target fits the request's context budget and provider body cap. Otherwise it falls back to the tier — never dispatches an oversized request.
- Fail open, always. Malformed output, a timeout, or a label outside the enum drops the override; the turn is never blocked. A valid task paired with a garbage tier token still applies the override, since the concrete model comes from local config, not the classifier.
- The sticky per-turn decision cache carries the task through tool-result continuations. `Server.Reload()` now resets that cache, so editing a policy takes effect on the next request instead of being masked by a stale decision.
- Pinned sessions (`X-Agentic-Pin-Model`, `pin_tiers`) bypass all of this, unchanged.
- A rule with no `tasks:` behaves exactly as before.

Selection and fallback ride the existing `reason` field (`task:implementation`, `task:sql_data:size-ineligible`), so route logs, route events, and eval traces pick it up with no schema migration.

## CLI

`agentic routing set` now loads the existing rule and merges flags onto it per-field, rather than rebuilding from flags alone — a task-only update no longer wipes the tiers. Repeatable `--task label=model`:

```
agentic routing set auto --task security_review=fable --task critical_review=opus
```

`routing list` gained a `TASKS` column.

## Compatibility

The config version is unchanged; the field is optional. Strict `KnownFields(true)` means an older binary reading a config with `tasks:` will refuse to start rather than silently misroute — documented in the README.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` all pass, including a `-race` run of the router/config/cmd packages. New coverage: every task label through the parser, combined tier+task classification, sticky task retention across continuations, valid-task/invalid-tier, classifier failure dropping the override, size-ineligible task target falling back, cache reset on reload, and task classification still running when size filtering leaves one eligible tier.

Applied live and confirmed with `agentic routing list` and `agentic doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)