### PR TITLE
Add official CLI subscription delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Run Claude Code on any model, with a budget.**
 
-agentic wraps Claude Code in a thin local router. Your sessions look and feel exactly like `claude` — same TUI, same tools, same updates — but the model behind them can be Anthropic, OpenAI, xAI, or anything OpenAI-compatible (Ollama, vLLM, OpenRouter, DeepSeek, Groq). Every token is metered, priced, and checked against budgets you set.
+agentic wraps Claude Code in a thin local router. Your sessions look and feel exactly like `claude` — same TUI, same tools, same updates — but the model behind them can be Anthropic, OpenAI, xAI, or anything OpenAI-compatible (Ollama, vLLM, OpenRouter, DeepSeek, Groq). Whole tasks can also be delegated to a locally logged-in Codex or Grok CLI under your own subscription. Every routed API token is metered, priced, and checked against budgets you set.
 
 ```bash
 agentic                  # Claude Code, tracked, on your default profile
@@ -40,10 +40,11 @@ agentic (launcher) ──▶ claude (unmodified, auto-updating)
                    local router (127.0.0.1)
                    ├─ anthropic: byte-faithful passthrough
                    ├─ openai dialect: full request/stream translation
+                   ├─ cli: whole-task delegation to local Codex/Grok
                    ├─ usage log (SQLite) + pricing
                    └─ budget gate
                           ▼
-        Anthropic · OpenAI · xAI · Ollama · vLLM · OpenRouter · ...
+        Anthropic · OpenAI · xAI · Ollama · vLLM · OpenRouter · Codex CLI · Grok CLI · ...
 ```
 
 There is no daemon. The first `agentic` session binds the router port and serves everyone; when it exits, another running session takes over within a couple of seconds. The last session out turns off the lights.
@@ -70,6 +71,10 @@ agentic providers add openai --type openai --base-url https://api.openai.com/v1 
     --key-env OPENAI_API_KEY --max-tokens-param max_completion_tokens
 agentic models add gpt --provider openai --id gpt-5.2 --reasoning effort --max-output 16384
 agentic models test gpt          # 1-token probe: did I configure it right?
+
+agentic providers add codex --type cli --dialect codex --sandbox workspace-write
+agentic models add codex --provider codex   # subscription login; no API key
+
 agentic budget set --daily 25
 ```
 
@@ -84,6 +89,8 @@ profiles:
   local: {model: qwen, small_fast: qwen}
   subscription: {passthrough: true}   # plain claude, subscription billing, no tracking
 ```
+
+Aliases backed by a `cli` provider are subagent-only: they cannot be a profile model, `small_fast`, or tier.
 
 ## Dynamic routing
 
@@ -131,7 +138,7 @@ agentic routing set auto --classifier haiku \
 agentic routing list
 ```
 
-A recognized task mapping takes precedence over the selected tier. Unrecognized or unmatched work uses the tier normally. If the mapped model cannot hold the request, the router falls back to the smallest eligible capability tier. Pinned sessions (`pin_tiers` / `X-Agentic-Pin-Model`) bypass task and tier classification entirely. Task classification is a model-selection hint, not a security boundary; enforce sensitive-work policy separately.
+A recognized task mapping takes precedence over the selected tier. Unrecognized or unmatched work uses the tier normally. If the mapped model cannot hold the request, the router falls back to the smallest eligible capability tier. Pinned sessions (`pin_tiers` / `X-Agentic-Pin-Model`) bypass task and tier classification entirely. A `cli` alias cannot appear as a classifier, tier, or task mapping; validation rejects it so auto-routing can never silently start an independent agent run in your repository. Task classification is a model-selection hint, not a security boundary; enforce sensitive-work policy separately.
 
 Every decision is logged, and task choices appear in the existing reason field:
 
@@ -257,7 +264,7 @@ main · sonnet · sess $0.84 · day $4.31/$25 [██░░░░]
 
 Two things you should understand before routing through agentic:
 
-- **Billing.** Traffic through the router is billed to **API keys**, not your Claude Pro/Max subscription. OAuth credentials are never proxied. For subscription billing, use a `passthrough: true` profile — normal claude, no tracking.
+- **Billing.** Normal traffic through the router is billed to **API keys**, not your Claude Pro/Max subscription. OAuth credentials are never proxied. For Claude subscription billing, use a `passthrough: true` profile — normal claude, no tracking. [CLI delegation](#delegating-to-another-cli) instead bills the peer CLI's own subscription (ChatGPT or SuperGrok/X Premium+) through its cached local login, which agentic invokes but never reads. That spend happens outside the router, so delegated runs appear in `agentic cost` as $0 unpriced rows with estimated token counts and budgets cannot gate them.
 - **Fidelity.** Non-Anthropic models work through translation, but Claude Code's prompts and tool patterns are tuned for Claude, so expect them to be clunkier in the main loop. They shine as cheap workhorses for background tasks and subagents. Specific gaps: no prompt caching on OpenAI-dialect backends (provider-side implicit caching still shows up as cache reads), thinking blocks are display-only, Anthropic server tools (web search, code execution) are unavailable on translated models, `top_k` is dropped, stop sequences truncate to four, and token counting for translated models is a deliberate ~15% overestimate so auto-compact fires early instead of overflowing context. Set `max_output` on models whose output cap is below what Claude Code requests (it asks for 32K), and `context_window` on models whose window differs from the ~200K Claude Code assumes (see [Context scaling](#context-scaling)).
 
 ## Subagents on any model
@@ -272,6 +279,30 @@ agentic agents list     # what's implied by your config, and what's pending
 Every model you've configured becomes selectable by name — `subagent_type: "agentic-qwen"`, `"agentic-grok"`, `"agentic-gpt-5-6-sol"` — and its traffic routes, prices, and budgets like any other agentic request. The set is derived from your own `models:` map, so it's whatever *you* configured; nothing is hardcoded.
 
 When your aliases change, the next `agentic` launch offers to refresh them (once — decline and it stays quiet until the aliases change again; `AGENTIC_NO_AGENT_SYNC=1` opts out entirely). Only files prefixed `agentic-` are ever written or removed, so your own subagents are never touched.
+
+Aliases backed by a `cli` provider get a deliberately different description: the generated definition tells the orchestrator that it is handing the entire task to an independent agent with filesystem access, so it writes a self-contained prompt and expects minutes of latency instead of a completion.
+
+## Delegating to another CLI
+
+If you already pay for ChatGPT or SuperGrok, a `cli` provider can delegate a whole task to the vendor's official, locally installed coding CLI under your own login:
+
+```bash
+# Install the CLI first, then authenticate it directly:
+codex login                       # ChatGPT subscription
+# or: grok login                  # SuperGrok / X Premium+ subscription
+
+agentic providers add codex --type cli --dialect codex --sandbox workspace-write
+agentic models add codex --provider codex
+agentic agents sync               # writes ~/.claude/agents/agentic-codex.md
+```
+
+Invoking `subagent_type: "agentic-codex"` hands that task prompt verbatim to `codex exec` (or `grok -p`) in the session's working directory. The CLI authenticates itself from its own cached login; agentic neither extracts nor reuses its OAuth token. Set `--id` on the model alias only if you want to pass a specific model to the peer CLI. Use provider `--command` to override the binary and `--timeout-ms` to override the 20-minute default.
+
+This is a whole agent loop, not a model completion: expect minutes of latency, no incremental output, and real file modifications. The delegated CLI sees only the one task prompt — no conversation history, system prompt, or Claude Code tool definitions — so make it self-contained. Its final message becomes the subagent result. Failures return as final message text instead of retryable stream errors, because silently repeating a filesystem-mutating run would be unsafe.
+
+Delegation is deliberately explicit-only. A `cli` alias cannot be a profile model, `small_fast`, tier, auto classifier, or task mapping. Bulk `agentic models test` also skips CLI aliases; name one explicitly (`agentic models test codex`) only when you intend to launch a real delegation.
+
+For Codex, choose the blast radius with `--sandbox read-only`, `workspace-write`, or `danger-full-access`. Delegation requires an `agentic`-launched session so the router receives and validates its absolute working directory; a bare `claude` session is refused rather than running the CLI in the router leader's unrelated directory.
 
 ## Finding another session
 
@@ -311,8 +342,8 @@ Cross-instance messaging is native to Claude Code — sessions register under `~
 | `agentic context [session-id]` | context-fullness trajectory (true vs reported tokens) |
 | `agentic eval run/report` | paired model evaluation and artifact report |
 | `agentic agents list/sync` | subagent definitions for your model aliases |
-| `agentic models add/list/remove/test/update-prices` | model aliases |
-| `agentic providers add/list/remove` | upstream providers |
+| `agentic models add/list/remove/test/update-prices` | model aliases (`test` skips CLI aliases unless one is named explicitly) |
+| `agentic providers add/list/remove` | API providers and official CLI delegates (`--type cli`) |
 | `agentic profiles list/show` · `agentic budget set` | profiles and caps |
 | `agentic config get/set` | any config key |
 | `agentic router run/status` | headless router / who's leader |
@@ -323,9 +354,13 @@ Cross-instance messaging is native to Claude Code — sessions register under `~
 
 Provider keys are referenced by environment variable name. They resolve in order: process environment → `~/.agentic/env` (a `KEY=value` file, mode 0600, created by `setup`). Put keys in `~/.agentic/env` — the router reads it directly, so sessions work no matter which shell launched them, and the config file never holds a secret.
 
+`cli` providers have no agentic key: `providers list` shows `· (subscription login)`, and `base_url` / `api_key_env` are rejected. Authentication belongs entirely to the official CLI.
+
 ## Security notes
 
 The router binds `127.0.0.1` only and requires a per-install token (created by `setup`, mode 0600), so other local processes can't spend on your keys.
+
+CLI delegation starts a local subprocess with filesystem access in the launching session's working directory. The launcher carries that directory in `X-Agentic-Cwd`; the backend requires an absolute existing directory before spawning anything. Codex's `--sandbox` setting controls its write scope. Treat `danger-full-access` accordingly.
 
 ## License
 

--- a/cmd/evalcmd.go
+++ b/cmd/evalcmd.go
@@ -138,6 +138,9 @@ func checkEvalModel(cfg *config.Config, what, alias string) error {
 		return fmt.Errorf("--%s model alias is required", what)
 	}
 	if _, ok := cfg.Models[alias]; ok {
+		if cfg.IsCLIAlias(alias) {
+			return fmt.Errorf("--%s %q is a cli alias — eval pins the whole candidate to one model, and cli aliases are explicit-subagent-only", what, alias)
+		}
 		return nil
 	}
 	if _, ok := cfg.Routing[alias]; ok {

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,13 +82,17 @@ var modelsAddCmd = &cobra.Command{
 	Short: "Add or update a model alias",
 	Example: `  agentic models add gpt  --provider openai --id gpt-5.2 --reasoning effort
   agentic models add grok --provider xai --id grok-4
-  agentic models add qwen --provider local --id qwen3-coder-30b`,
+  agentic models add qwen --provider local --id qwen3-coder-30b
+  agentic models add codex --provider codex`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if modelProvider == "" || modelID == "" {
-			return fmt.Errorf("--provider and --id are required")
+		if modelProvider == "" {
+			return fmt.Errorf("--provider is required")
 		}
-		snippet := fmt.Sprintf("provider: %s\nid: %s\n", modelProvider, yamlQuote(modelID))
+		snippet := fmt.Sprintf("provider: %s\n", modelProvider)
+		if modelID != "" {
+			snippet += fmt.Sprintf("id: %s\n", yamlQuote(modelID))
+		}
 		if modelReasoning != "" {
 			snippet += "reasoning: " + modelReasoning + "\n"
 		}
@@ -142,7 +147,18 @@ var modelsTestCmd = &cobra.Command{
 			sort.Strings(aliases)
 		}
 		failed := 0
+		explicit := len(args) == 1
 		for _, alias := range aliases {
+			model, ok := cfg.Models[alias]
+			if !ok {
+				failed++
+				fmt.Printf("✗ %-12s model alias not found\n", alias)
+				continue
+			}
+			if !explicit && cfg.Providers[model.Provider].Type == config.ProviderCLI {
+				fmt.Printf("· %-12s (cli) — skipped; run %q to invoke it for real\n", alias, "agentic models test "+alias)
+				continue
+			}
 			start := time.Now()
 			err := probeModel(baseURL, token, alias)
 			if err != nil {
@@ -167,6 +183,9 @@ func probeModel(baseURL, token, alias string) error {
 	}
 	req.Header.Set("x-api-key", token)
 	req.Header.Set("content-type", "application/json")
+	if cwd, err := os.Getwd(); err == nil {
+		req.Header.Set("X-Agentic-Cwd", cwd)
+	}
 	client := &http.Client{Timeout: 60 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -183,12 +202,42 @@ func probeModel(baseURL, token, alias string) error {
 
 // ensureRouter joins the existing leader or runs one in-process for the
 // duration of the command.
+func portAvailable(port int) (bool, error) {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return false, err
+	}
+	return true, ln.Close()
+}
+
+func freePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	return port, ln.Close()
+}
+
 func ensureRouter(ctx context.Context, cfg *config.Config, dataDir string) (string, string, func(), error) {
 	token, err := launch.Token(dataDir)
 	if err != nil {
 		return "", "", nil, err
 	}
-	mgr := &router.Manager{Port: cfg.Router.Port, Token: token, DataDir: dataDir, Log: logger()}
+	port := cfg.Router.Port
+	// A router leader belongs to one agentic data directory/token. If another
+	// install (most commonly a test with a temporary HOME) already owns the
+	// configured port, pick another local port rather than joining it and
+	// sending that unrelated leader our token/config.
+	if discovery, err := router.ReadDiscovery(dataDir); err != nil || discovery.Port != port {
+		if available, err := portAvailable(port); err != nil || !available {
+			port, err = freePort()
+			if err != nil {
+				return "", "", nil, fmt.Errorf("selecting temporary router port: %w", err)
+			}
+		}
+	}
+	mgr := &router.Manager{Port: port, Token: token, DataDir: dataDir, Log: logger()}
 	runCtx, cancel := context.WithCancel(context.Background())
 	go mgr.Run(runCtx)
 	if err := mgr.Ensure(ctx); err != nil {
@@ -236,7 +285,7 @@ var modelsUpdatePricesCmd = &cobra.Command{
 
 func init() {
 	modelsAddCmd.Flags().StringVar(&modelProvider, "provider", "", "provider name from config")
-	modelsAddCmd.Flags().StringVar(&modelID, "id", "", "upstream model id")
+	modelsAddCmd.Flags().StringVar(&modelID, "id", "", "upstream model id (optional for cli providers)")
 	modelsAddCmd.Flags().StringVar(&modelReasoning, "reasoning", "", "none | effort | passive")
 	modelsAddCmd.Flags().IntVar(&modelMaxOutput, "max-output", 0, "clamp max_tokens to this output cap")
 	modelsAddCmd.Flags().IntVar(&modelCtxWindow, "context-window", 0, "model's real input context window in tokens")

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -89,6 +89,17 @@ var modelsAddCmd = &cobra.Command{
 		if modelProvider == "" {
 			return fmt.Errorf("--provider is required")
 		}
+		cfg, _, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		p, ok := cfg.Providers[modelProvider]
+		if !ok {
+			return fmt.Errorf("unknown provider %q", modelProvider)
+		}
+		if p.Type != config.ProviderCLI && modelID == "" {
+			return fmt.Errorf("--id is required for %s providers", p.Type)
+		}
 		snippet := fmt.Sprintf("provider: %s\n", modelProvider)
 		if modelID != "" {
 			snippet += fmt.Sprintf("id: %s\n", yamlQuote(modelID))
@@ -160,7 +171,14 @@ var modelsTestCmd = &cobra.Command{
 				continue
 			}
 			start := time.Now()
-			err := probeModel(baseURL, token, alias)
+			timeout := 60 * time.Second
+			if cfg.Providers[model.Provider].Type == config.ProviderCLI {
+				timeout = 20 * time.Minute
+				if cfg.Providers[model.Provider].TimeoutMS > 0 {
+					timeout = time.Duration(cfg.Providers[model.Provider].TimeoutMS)*time.Millisecond + time.Minute
+				}
+			}
+			err := probeModel(baseURL, token, alias, timeout)
 			if err != nil {
 				failed++
 				fmt.Printf("✗ %-12s %v\n", alias, err)
@@ -175,7 +193,7 @@ var modelsTestCmd = &cobra.Command{
 	},
 }
 
-func probeModel(baseURL, token, alias string) error {
+func probeModel(baseURL, token, alias string, timeout time.Duration) error {
 	body := fmt.Sprintf(`{"model":%q,"max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`, alias)
 	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/messages", strings.NewReader(body))
 	if err != nil {
@@ -186,7 +204,10 @@ func probeModel(baseURL, token, alias string) error {
 	if cwd, err := os.Getwd(); err == nil {
 		req.Header.Set("X-Agentic-Cwd", cwd)
 	}
-	client := &http.Client{Timeout: 60 * time.Second}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -12,11 +12,15 @@ import (
 )
 
 var (
-	provType   string
-	provBase   string
-	provKeyEnv string
-	provMaxTok string
-	provMaxReq int64
+	provType    string
+	provBase    string
+	provKeyEnv  string
+	provMaxTok  string
+	provMaxReq  int64
+	provDialect string
+	provCommand string
+	provSandbox string
+	provTimeout int
 )
 
 var providersCmd = &cobra.Command{
@@ -43,6 +47,8 @@ var providersListCmd = &cobra.Command{
 			p := cfg.Providers[n]
 			key := "✓"
 			switch {
+			case p.Type == config.ProviderCLI:
+				key = "· (subscription login)"
 			case p.APIKey != "":
 				key = "✓ (literal)"
 			case p.APIKeyEnv == "":
@@ -50,7 +56,11 @@ var providersListCmd = &cobra.Command{
 			case p.Key() == "":
 				key = "✗ (" + p.APIKeyEnv + " unavailable)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", n, p.Type, p.BaseURL, key)
+			base := p.BaseURL
+			if p.Type == config.ProviderCLI {
+				base = "(" + p.Bin() + " CLI, " + p.Dialect + " dialect)"
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", n, p.Type, base, key)
 		}
 		return tw.Flush()
 	},
@@ -64,11 +74,35 @@ var providersAddCmd = &cobra.Command{
   agentic providers add openai --type openai --base-url https://api.openai.com/v1 \
       --key-env OPENAI_API_KEY --max-tokens-param max_completion_tokens
   agentic providers add xai   --type openai --base-url https://api.x.ai/v1 --key-env XAI_API_KEY
-  agentic providers add local --type openai --base-url http://localhost:11434/v1 --key-env ""`,
+  agentic providers add local --type openai --base-url http://localhost:11434/v1 --key-env ""
+
+A "cli" provider delegates whole tasks to a locally installed coding-agent
+CLI running under your own subscription login (codex login / grok login):
+
+  agentic providers add codex --type cli --dialect codex --sandbox workspace-write
+  agentic providers add grokcli --type cli --dialect grok`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if provType == config.ProviderCLI {
+			if provDialect == "" {
+				return fmt.Errorf("--dialect is required for cli providers (%s | %s)", config.CLIDialectCodex, config.CLIDialectGrok)
+			}
+			snippet := fmt.Sprintf("type: %s\ndialect: %s\n", provType, provDialect)
+			if provCommand != "" {
+				snippet += fmt.Sprintf("command: %s\n", yamlQuote(provCommand))
+			}
+			if provSandbox != "" {
+				snippet += fmt.Sprintf("sandbox: %s\n", provSandbox)
+			}
+			if provTimeout > 0 {
+				snippet += fmt.Sprintf("timeout_ms: %d\n", provTimeout)
+			}
+			return editConfig(func(doc *config.Doc) error {
+				return doc.SetSubtree("providers", args[0], snippet)
+			}, "provider "+args[0])
+		}
 		if provType != config.ProviderAnthropic && provType != config.ProviderOpenAI {
-			return fmt.Errorf("--type must be %q or %q", config.ProviderAnthropic, config.ProviderOpenAI)
+			return fmt.Errorf("--type must be %q, %q, or %q", config.ProviderAnthropic, config.ProviderOpenAI, config.ProviderCLI)
 		}
 		if provBase == "" {
 			return fmt.Errorf("--base-url is required")
@@ -99,10 +133,14 @@ var providersRemoveCmd = &cobra.Command{
 }
 
 func init() {
-	providersAddCmd.Flags().StringVar(&provType, "type", "openai", "provider dialect: anthropic | openai")
+	providersAddCmd.Flags().StringVar(&provType, "type", "openai", "provider dialect: anthropic | openai | cli")
 	providersAddCmd.Flags().StringVar(&provBase, "base-url", "", "API base URL")
 	providersAddCmd.Flags().StringVar(&provKeyEnv, "key-env", "", "env var holding the API key (empty = no auth)")
 	providersAddCmd.Flags().StringVar(&provMaxTok, "max-tokens-param", "", "max_tokens | max_completion_tokens")
 	providersAddCmd.Flags().Int64Var(&provMaxReq, "max-request-bytes", 0, "upstream request body cap in bytes (refuses oversized requests pre-dispatch; 0 = none)")
+	providersAddCmd.Flags().StringVar(&provDialect, "dialect", "", "cli providers: codex | grok")
+	providersAddCmd.Flags().StringVar(&provCommand, "command", "", "cli providers: binary name or path (default: the dialect name)")
+	providersAddCmd.Flags().StringVar(&provSandbox, "sandbox", "", "cli providers (codex only): read-only | workspace-write | danger-full-access")
+	providersAddCmd.Flags().IntVar(&provTimeout, "timeout-ms", 0, "cli providers: per-delegation deadline (0 = 20m default)")
 	providersCmd.AddCommand(providersListCmd, providersAddCmd, providersRemoveCmd)
 }

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -87,6 +87,12 @@ CLI running under your own subscription login (codex login / grok login):
 			if provDialect == "" {
 				return fmt.Errorf("--dialect is required for cli providers (%s | %s)", config.CLIDialectCodex, config.CLIDialectGrok)
 			}
+			if provBase != "" || provKeyEnv != "" || provMaxTok != "" || provMaxReq != 0 {
+				return fmt.Errorf("--base-url/--key-env/--max-tokens-param/--max-request-bytes do not apply to cli providers")
+			}
+			if provTimeout < 0 {
+				return fmt.Errorf("--timeout-ms must be >= 0")
+			}
 			snippet := fmt.Sprintf("type: %s\ndialect: %s\n", provType, provDialect)
 			if provCommand != "" {
 				snippet += fmt.Sprintf("command: %s\n", yamlQuote(provCommand))

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -102,13 +102,18 @@ providers:
   #   type: openai                       # Ollama / vLLM / any OpenAI-compatible server
   #   base_url: http://localhost:11434/v1
   #   api_key_env: ""
+  # codex:
+  #   type: cli                          # whole-task delegation to the official CLI
+  #   dialect: codex                     # codex | grok
+  #   sandbox: workspace-write           # codex only
 
 models:                # alias -> upstream; aliases flow into ANTHROPIC_MODEL
   opus:   {provider: anthropic, id: claude-opus-4-8}
   sonnet: {provider: anthropic, id: claude-sonnet-5}
   haiku:  {provider: anthropic, id: claude-haiku-4-5}
-  # gpt:  {provider: openai, id: gpt-5.2, reasoning: effort, max_output: 16384}
-  # grok: {provider: xai, id: grok-4}
+  # gpt:   {provider: openai, id: gpt-5.2, reasoning: effort, max_output: 16384}
+  # grok:  {provider: xai, id: grok-4}
+  # codex: {provider: codex}             # id optional; explicit subagent use only
 
 profiles:
   main:

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -59,6 +59,10 @@ func definitionFor(cfg *config.Config, alias string) Definition {
 	name := Prefix + slug(alias)
 	m := cfg.Models[alias]
 
+	if cfg.Providers[m.Provider].Type == config.ProviderCLI {
+		return cliDefinition(cfg, alias, name)
+	}
+
 	// Describe the model concretely so the orchestrating model can tell the
 	// generated agents apart when choosing one.
 	var facts []string
@@ -89,6 +93,42 @@ Complete the task you were given and report the result. Your final message
 is the return value the caller receives, so make it the answer itself — not
 a description of what you did.
 `, name, alias, detail, alias, alias, orUnknown(m.ID))
+
+	return Definition{Alias: alias, Name: name, Filename: name + ".md", Body: body}
+}
+
+// cliDefinition describes a cli-delegation alias honestly: it is a whole
+// independent coding agent under the user's own subscription, not a model
+// completion — the orchestrator must know about the latency, filesystem
+// side effects, and the need for a self-contained prompt.
+func cliDefinition(cfg *config.Config, alias, name string) Definition {
+	m := cfg.Models[alias]
+	p := cfg.Providers[m.Provider]
+	cliName, subscription := "the "+p.Dialect+" CLI", "its own subscription"
+	switch p.Dialect {
+	case config.CLIDialectCodex:
+		cliName, subscription = "the Codex CLI (`codex exec`)", "your own ChatGPT subscription"
+	case config.CLIDialectGrok:
+		cliName, subscription = "the Grok Build CLI (`grok -p`)", "your own SuperGrok/X Premium+ subscription"
+	}
+	modelNote := ""
+	if m.ID != "" {
+		modelNote = fmt.Sprintf(" (model %s)", m.ID)
+	}
+
+	body := fmt.Sprintf(`---
+name: %s
+description: Delegates the ENTIRE task to %s%s running under %s. It is an independent coding agent with filesystem access in the working directory — expect minutes of latency, no incremental streaming, and possible file modifications. Use for self-contained subtasks you want a second agent to complete end to end.
+model: %s
+---
+
+Your task prompt is handed verbatim to %s, which runs its own agent loop in
+the session's working directory under %s. It sees NONE of the conversation —
+only this prompt — so make the task fully self-contained: what to do, where,
+and what to report back.
+
+The CLI's final message is returned as your result.
+`, name, cliName, modelNote, subscription, alias, cliName, subscription)
 
 	return Definition{Alias: alias, Name: name, Filename: name + ".md", Body: body}
 }

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -55,6 +55,33 @@ func TestDesiredEmitsAliasAsModel(t *testing.T) {
 	}
 }
 
+func TestDesiredDescribesCLIDelegation(t *testing.T) {
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"codex-cli": {Type: config.ProviderCLI, Dialect: config.CLIDialectCodex},
+		},
+		Models: map[string]config.Model{
+			"codex": {Provider: "codex-cli"},
+		},
+	}
+	got := Desired(cfg)
+	if len(got) != 1 {
+		t.Fatalf("got %d definitions, want 1", len(got))
+	}
+	body := got[0].Body
+	for _, want := range []string{
+		"model: codex",
+		"Delegates the ENTIRE task",
+		"your own ChatGPT subscription",
+		"possible file modifications",
+		"It sees NONE of the conversation",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("cli definition missing %q:\n%s", want, body)
+		}
+	}
+}
+
 // Routing rules are classifier rules, not concrete models — a subagent that
 // silently re-tiers itself would make the chosen model unpredictable.
 func TestDesiredExcludesRoutingRules(t *testing.T) {

--- a/internal/backend/clibe/clibe.go
+++ b/internal/backend/clibe/clibe.go
@@ -6,9 +6,9 @@
 // session's working directory, so a request here is minutes of autonomous
 // work, not a completion — which is why config validation keeps cli aliases
 // out of auto-routing and profile tiers, and why failures are surfaced as
-// message text with end_turn instead of a retryable SSE error event: Claude
-// Code retries error events, and re-running a filesystem-mutating agent is
-// the one thing this backend must never cause.
+// message text with end_turn instead of a retryable HTTP/SSE error: Claude
+// Code retries those, and re-running a filesystem-mutating agent is the one
+// thing this backend must never cause.
 package clibe
 
 import (
@@ -41,9 +41,12 @@ import (
 const CwdHeader = "X-Agentic-Cwd"
 
 const (
-	defaultTimeout  = 20 * time.Minute
-	stderrTailBytes = 32 * 1024
-	pingInterval    = 15 * time.Second
+	defaultTimeout   = 20 * time.Minute
+	stderrTailBytes  = 32 * 1024
+	stdoutLimitBytes = 1 << 20
+	maxTaskBytes     = 100_000
+	pingInterval     = 15 * time.Second
+	teardownWait     = 5 * time.Second
 )
 
 // Executor is the process-exec seam (mirrors internal/eval's; duplicated so
@@ -55,17 +58,36 @@ type Executor interface {
 type OSExecutor struct{}
 
 func (OSExecutor) Run(ctx context.Context, dir string, env, argv []string, stdin io.Reader, stdout, stderr io.Writer) error {
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	if len(argv) == 0 {
+		return errors.New("empty argv")
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
 	cmd.Dir, cmd.Env, cmd.Stdin, cmd.Stdout, cmd.Stderr = dir, env, stdin, stdout, stderr
-	return cmd.Run()
+	isolateProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		killProcessTree(cmd)
+		select {
+		case <-done:
+		case <-time.After(teardownWait):
+		}
+		return ctx.Err()
+	}
 }
 
 type Backend struct {
 	Exec     Executor
 	LookPath func(string) (string, error)
-	// Home overrides the login-preflight base directory (tests only; ""
-	// means os.UserHomeDir).
-	Home string
+	// Environ, when set, replaces os.Environ for the delegated process
+	// (tests only).
+	Environ func() []string
 }
 
 func New() *Backend {
@@ -87,9 +109,6 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 	if _, err := b.LookPath(bin); err != nil {
 		return refuse(w, fmt.Sprintf("%s CLI (%q) not found on PATH — install it first (%s)", prov.Dialect, bin, installHint(prov.Dialect)))
 	}
-	if msg := b.loginCheck(prov.Dialect); msg != "" {
-		return refuse(w, msg)
-	}
 
 	req, err := anthropic.ParseRequest(call.Raw)
 	if err != nil {
@@ -99,6 +118,9 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 	if task == "" {
 		return refuse(w, "cli delegation found no task text in the request")
 	}
+	if len(task) > maxTaskBytes {
+		return refuse(w, fmt.Sprintf("cli delegation task is %d bytes; keep it under %d so it can be passed as a single argv element", len(task), maxTaskBytes))
+	}
 
 	timeout := defaultTimeout
 	if prov.TimeoutMS > 0 {
@@ -106,66 +128,92 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 	}
 	argv := buildArgv(prov, call.Route.Model.ID, task)
 
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	// Open the stream before the run so keep-alive pings hold the
-	// connection through a multi-minute delegation.
+	// connection through a multi-minute delegation. A failed first write
+	// means the client is already gone — do not spawn.
 	var sse *anthropic.SSEWriter
 	estIn := estimateTokens(task)
 	if call.Envelope.Stream {
 		sse = anthropic.NewSSEWriter(w)
-		sse.Event("message_start", map[string]any{
+		if err := sse.Event("message_start", map[string]any{
 			"type": "message_start",
 			"message": anthropic.MessagesResponse{
 				ID: "msg_agentic_cli", Type: "message", Role: "assistant",
 				Model: call.Route.Alias, Content: []anthropic.ContentBlock{},
 				Usage: anthropic.Usage{InputTokens: estIn},
 			},
-		})
-		sse.Ping()
+		}); err != nil {
+			return backend.Result{Status: 499, ErrType: "client_disconnect", ErrMsg: "client disconnected before delegation", Usage: anthropic.Usage{InputTokens: estIn}, ReportedInput: estIn}
+		}
+		if err := sse.Ping(); err != nil {
+			return backend.Result{Status: 499, ErrType: "client_disconnect", ErrMsg: "client disconnected before delegation", Usage: anthropic.Usage{InputTokens: estIn}, ReportedInput: estIn}
+		}
 	}
 
-	runCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	var stdout bytes.Buffer
+	var stdout limitedBuffer
+	stdout.max = stdoutLimitBytes
 	stderr := &tailWriter{max: stderrTailBytes}
 	done := make(chan error, 1)
 	go func() {
-		done <- b.Exec.Run(runCtx, cwd, os.Environ(), argv, nil, &stdout, stderr)
+		done <- b.Exec.Run(runCtx, cwd, sanitizeEnv(b.environ()), argv, nil, &stdout, stderr)
 	}()
 	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 	var runErr error
+	timedOut := false
 wait:
 	for {
 		select {
 		case runErr = <-done:
 			break wait
+		case <-runCtx.Done():
+			timedOut = errors.Is(runCtx.Err(), context.DeadlineExceeded)
+			select {
+			case runErr = <-done:
+			case <-time.After(teardownWait):
+				if runErr == nil {
+					runErr = runCtx.Err()
+				}
+			}
+			break wait
 		case <-ticker.C:
-			if sse != nil {
-				sse.Ping() // single goroutine writes all events — no locking needed
+			if sse != nil && sse.Ping() != nil {
+				cancel()
 			}
 		}
 	}
 
-	// Client gone: the subprocess was killed via runCtx; nothing left to write.
-	if ctx.Err() != nil && !errors.Is(runCtx.Err(), context.DeadlineExceeded) {
-		return backend.Result{Status: 499, ErrType: "client_disconnect", ErrMsg: "client disconnected mid-delegation"}
+	// Client gone after a completed run: keep the completed result. Only
+	// classify disconnect when cancellation actually stopped the process.
+	if ctx.Err() != nil && !timedOut && errors.Is(runErr, context.Canceled) {
+		return backend.Result{Status: 499, ErrType: "client_disconnect", ErrMsg: "client disconnected mid-delegation", Usage: anthropic.Usage{InputTokens: estIn}, ReportedInput: estIn}
 	}
 
-	text, res := stdoutText(stdout.Bytes()), backend.Result{Status: 200}
+	text := stdoutText(stdout.Bytes())
+	// After spawn, always write a finished assistant turn (HTTP 200 /
+	// end_turn). A 4xx/5xx or SSE error event would make Claude Code retry
+	// a filesystem-mutating agent. Status/ErrType on Result stay for logs.
+	res := backend.Result{Status: 200}
 	switch {
-	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+	case timedOut || errors.Is(runErr, context.DeadlineExceeded):
 		text = fmt.Sprintf("agentic: %s delegation timed out after %s; partial changes may exist in %s", prov.Dialect, timeout, cwd)
-		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: "delegation timeout"}
+		res.ErrType, res.ErrMsg = "api_error", "delegation timeout"
 	case runErr != nil:
 		msg := runErr.Error()
 		if tail := stderr.String(); tail != "" {
 			msg += ": " + tail
 		}
 		text = fmt.Sprintf("agentic: %s delegation failed (%s)", prov.Dialect, msg)
-		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: truncate(msg, 512)}
+		res.ErrType, res.ErrMsg = "api_error", truncate(msg, 512)
 	case text == "":
 		text = fmt.Sprintf("agentic: %s delegation produced no output", prov.Dialect)
-		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: "empty delegation output"}
+		res.ErrType, res.ErrMsg = "api_error", "empty delegation output"
+	}
+	if stdout.truncated {
+		text += "\n\nagentic: stdout truncated at 1MiB"
 	}
 	// Heuristic usage so the delegation shows up in `agentic cost` as a $0
 	// unpriced row (validation forbids pricing on cli models).
@@ -173,27 +221,24 @@ wait:
 	res.ReportedInput = estIn
 
 	if sse != nil {
-		sse.Event("content_block_start", map[string]any{
+		_ = sse.Event("content_block_start", map[string]any{
 			"type": "content_block_start", "index": 0,
 			"content_block": map[string]string{"type": "text", "text": ""},
 		})
-		sse.Event("content_block_delta", map[string]any{
+		_ = sse.Event("content_block_delta", map[string]any{
 			"type": "content_block_delta", "index": 0,
 			"delta": map[string]string{"type": "text_delta", "text": text},
 		})
-		sse.Event("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
-		sse.Event("message_delta", map[string]any{
+		_ = sse.Event("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+		_ = sse.Event("message_delta", map[string]any{
 			"type":  "message_delta",
 			"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
 			"usage": map[string]int64{"input_tokens": res.Usage.InputTokens, "output_tokens": res.Usage.OutputTokens},
 		})
-		sse.Event("message_stop", map[string]any{"type": "message_stop"})
+		_ = sse.Event("message_stop", map[string]any{"type": "message_stop"})
 		return res
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if res.Status >= 400 {
-		w.WriteHeader(res.Status)
-	}
 	json.NewEncoder(w).Encode(anthropic.MessagesResponse{
 		ID: "msg_agentic_cli", Type: "message", Role: "assistant",
 		Model:      call.Route.Alias,
@@ -228,33 +273,39 @@ func refuse(w http.ResponseWriter, msg string) backend.Result {
 	return backend.Result{Status: 400, ErrType: "invalid_request_error", ErrMsg: truncate(msg, 512)}
 }
 
-// loginCheck cheaply detects a missing subscription login before spending a
-// subprocess spawn. Heuristic by design: the auth file existing doesn't prove
-// the token is fresh (the CLI itself is the authority and will fail with its
-// own message), but its absence proves login never happened.
-func (b *Backend) loginCheck(dialect string) string {
-	home := b.Home
-	if home == "" {
-		home, _ = os.UserHomeDir()
+func (b *Backend) environ() []string {
+	if b.Environ != nil {
+		return b.Environ()
 	}
-	switch dialect {
-	case config.CLIDialectCodex:
-		dir := os.Getenv("CODEX_HOME")
-		if dir == "" {
-			dir = filepath.Join(home, ".codex")
-		}
-		if _, err := os.Stat(filepath.Join(dir, "auth.json")); err != nil {
-			return "codex CLI is not logged in — run `codex login` (uses your ChatGPT subscription)"
-		}
-	case config.CLIDialectGrok:
-		if os.Getenv("XAI_API_KEY") != "" {
-			return ""
-		}
-		if _, err := os.Stat(filepath.Join(home, ".grok", "auth.json")); err != nil {
-			return "grok CLI is not logged in — run `grok login` (uses your SuperGrok/X Premium+ subscription)"
-		}
+	return os.Environ()
+}
+
+// sanitizeEnv drops agentic/router credentials and unrelated provider keys
+// from the delegated process. The peer CLI authenticates itself from its own
+// login; it does not need the launcher's secrets.
+func sanitizeEnv(env []string) []string {
+	drop := map[string]bool{
+		"ANTHROPIC_BASE_URL":         true,
+		"ANTHROPIC_AUTH_TOKEN":       true,
+		"ANTHROPIC_API_KEY":          true,
+		"ANTHROPIC_CUSTOM_HEADERS":   true,
+		"ANTHROPIC_MODEL":            true,
+		"ANTHROPIC_SMALL_FAST_MODEL": true,
+		"CLAUDE_CODE_SUBAGENT_MODEL": true,
+		"AGENTIC_SESSION_ID":         true,
+		"AGENTIC_PROFILE":            true,
+		"OPENAI_API_KEY":             true,
+		"XAI_API_KEY":                true,
 	}
-	return ""
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if drop[key] || strings.HasPrefix(key, "ANTHROPIC_DEFAULT_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
 }
 
 func installHint(dialect string) string {
@@ -376,3 +427,27 @@ func (t *tailWriter) Write(p []byte) (int, error) {
 func (t *tailWriter) String() string {
 	return strings.TrimSpace(string(t.buf))
 }
+
+// limitedBuffer keeps at most max bytes and records whether it discarded the
+// rest, so a verbose CLI cannot grow the shared router leader without bound.
+type limitedBuffer struct {
+	buf       bytes.Buffer
+	max       int
+	truncated bool
+}
+
+func (b *limitedBuffer) Write(p []byte) (int, error) {
+	remain := b.max - b.buf.Len()
+	if remain <= 0 {
+		b.truncated = true
+		return len(p), nil
+	}
+	if len(p) > remain {
+		b.buf.Write(p[:remain])
+		b.truncated = true
+		return len(p), nil
+	}
+	return b.buf.Write(p)
+}
+
+func (b *limitedBuffer) Bytes() []byte { return b.buf.Bytes() }

--- a/internal/backend/clibe/clibe.go
+++ b/internal/backend/clibe/clibe.go
@@ -1,0 +1,378 @@
+// Package clibe delegates a whole task to a locally installed coding-agent
+// CLI (Codex, Grok Build) running under the user's own subscription login.
+// agentic never sees the CLI's credentials — the binary authenticates itself
+// from its own cached login (`codex login` / `grok login`). The delegated CLI
+// runs its own independent agent loop with filesystem access in the calling
+// session's working directory, so a request here is minutes of autonomous
+// work, not a completion — which is why config validation keeps cli aliases
+// out of auto-routing and profile tiers, and why failures are surfaced as
+// message text with end_turn instead of a retryable SSE error event: Claude
+// Code retries error events, and re-running a filesystem-mutating agent is
+// the one thing this backend must never cause.
+package clibe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/backend"
+	"github.com/maorbril/agentic/internal/config"
+	"github.com/maorbril/agentic/internal/tokens"
+)
+
+// CwdHeader carries the launching session's working directory on every
+// request (set via ANTHROPIC_CUSTOM_HEADERS in internal/launch). The router
+// leader is a long-lived shared process, so its own cwd is meaningless — the
+// delegated CLI must run where the session runs. The header is set by the
+// same local trusted launch process and every request is gated by the
+// per-install token, so this is not a cross-trust boundary; the backend still
+// validates it (absolute, existing directory) as defense against bugs.
+const CwdHeader = "X-Agentic-Cwd"
+
+const (
+	defaultTimeout  = 20 * time.Minute
+	stderrTailBytes = 32 * 1024
+	pingInterval    = 15 * time.Second
+)
+
+// Executor is the process-exec seam (mirrors internal/eval's; duplicated so
+// the backend doesn't depend on the eval package).
+type Executor interface {
+	Run(ctx context.Context, dir string, env, argv []string, stdin io.Reader, stdout, stderr io.Writer) error
+}
+
+type OSExecutor struct{}
+
+func (OSExecutor) Run(ctx context.Context, dir string, env, argv []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir, cmd.Env, cmd.Stdin, cmd.Stdout, cmd.Stderr = dir, env, stdin, stdout, stderr
+	return cmd.Run()
+}
+
+type Backend struct {
+	Exec     Executor
+	LookPath func(string) (string, error)
+	// Home overrides the login-preflight base directory (tests only; ""
+	// means os.UserHomeDir).
+	Home string
+}
+
+func New() *Backend {
+	return &Backend{Exec: OSExecutor{}, LookPath: exec.LookPath}
+}
+
+func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
+	prov := call.Route.Provider
+
+	cwd := call.Header.Get(CwdHeader)
+	if cwd == "" || !filepath.IsAbs(cwd) {
+		return refuse(w, "cli delegation needs the session working directory (launch via `agentic` so "+CwdHeader+" is set)")
+	}
+	if st, err := os.Stat(cwd); err != nil || !st.IsDir() {
+		return refuse(w, fmt.Sprintf("cli delegation working directory %q is not an existing directory", cwd))
+	}
+
+	bin := prov.Bin()
+	if _, err := b.LookPath(bin); err != nil {
+		return refuse(w, fmt.Sprintf("%s CLI (%q) not found on PATH — install it first (%s)", prov.Dialect, bin, installHint(prov.Dialect)))
+	}
+	if msg := b.loginCheck(prov.Dialect); msg != "" {
+		return refuse(w, msg)
+	}
+
+	req, err := anthropic.ParseRequest(call.Raw)
+	if err != nil {
+		return refuse(w, err.Error())
+	}
+	task := taskText(req)
+	if task == "" {
+		return refuse(w, "cli delegation found no task text in the request")
+	}
+
+	timeout := defaultTimeout
+	if prov.TimeoutMS > 0 {
+		timeout = time.Duration(prov.TimeoutMS) * time.Millisecond
+	}
+	argv := buildArgv(prov, call.Route.Model.ID, task)
+
+	// Open the stream before the run so keep-alive pings hold the
+	// connection through a multi-minute delegation.
+	var sse *anthropic.SSEWriter
+	estIn := estimateTokens(task)
+	if call.Envelope.Stream {
+		sse = anthropic.NewSSEWriter(w)
+		sse.Event("message_start", map[string]any{
+			"type": "message_start",
+			"message": anthropic.MessagesResponse{
+				ID: "msg_agentic_cli", Type: "message", Role: "assistant",
+				Model: call.Route.Alias, Content: []anthropic.ContentBlock{},
+				Usage: anthropic.Usage{InputTokens: estIn},
+			},
+		})
+		sse.Ping()
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var stdout bytes.Buffer
+	stderr := &tailWriter{max: stderrTailBytes}
+	done := make(chan error, 1)
+	go func() {
+		done <- b.Exec.Run(runCtx, cwd, os.Environ(), argv, nil, &stdout, stderr)
+	}()
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+	var runErr error
+wait:
+	for {
+		select {
+		case runErr = <-done:
+			break wait
+		case <-ticker.C:
+			if sse != nil {
+				sse.Ping() // single goroutine writes all events — no locking needed
+			}
+		}
+	}
+
+	// Client gone: the subprocess was killed via runCtx; nothing left to write.
+	if ctx.Err() != nil && !errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		return backend.Result{Status: 499, ErrType: "client_disconnect", ErrMsg: "client disconnected mid-delegation"}
+	}
+
+	text, res := stdoutText(stdout.Bytes()), backend.Result{Status: 200}
+	switch {
+	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
+		text = fmt.Sprintf("agentic: %s delegation timed out after %s; partial changes may exist in %s", prov.Dialect, timeout, cwd)
+		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: "delegation timeout"}
+	case runErr != nil:
+		msg := runErr.Error()
+		if tail := stderr.String(); tail != "" {
+			msg += ": " + tail
+		}
+		text = fmt.Sprintf("agentic: %s delegation failed (%s)", prov.Dialect, msg)
+		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: truncate(msg, 512)}
+	case text == "":
+		text = fmt.Sprintf("agentic: %s delegation produced no output", prov.Dialect)
+		res = backend.Result{Status: 502, ErrType: "api_error", ErrMsg: "empty delegation output"}
+	}
+	// Heuristic usage so the delegation shows up in `agentic cost` as a $0
+	// unpriced row (validation forbids pricing on cli models).
+	res.Usage = anthropic.Usage{InputTokens: estIn, OutputTokens: estimateTokens(text)}
+	res.ReportedInput = estIn
+
+	if sse != nil {
+		sse.Event("content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]string{"type": "text", "text": ""},
+		})
+		sse.Event("content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": 0,
+			"delta": map[string]string{"type": "text_delta", "text": text},
+		})
+		sse.Event("content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+		sse.Event("message_delta", map[string]any{
+			"type":  "message_delta",
+			"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
+			"usage": map[string]int64{"input_tokens": res.Usage.InputTokens, "output_tokens": res.Usage.OutputTokens},
+		})
+		sse.Event("message_stop", map[string]any{"type": "message_stop"})
+		return res
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if res.Status >= 400 {
+		w.WriteHeader(res.Status)
+	}
+	json.NewEncoder(w).Encode(anthropic.MessagesResponse{
+		ID: "msg_agentic_cli", Type: "message", Role: "assistant",
+		Model:      call.Route.Alias,
+		Content:    []anthropic.ContentBlock{{Type: "text", Text: text}},
+		StopReason: "end_turn",
+		Usage:      res.Usage,
+	})
+	return res
+}
+
+// CountTokens serves a local estimate, like openaibe; cli models have no
+// context budget (validation forbids one) so the scale factor is 1.
+func (b *Backend) CountTokens(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
+	req, err := anthropic.ParseRequest(call.Raw)
+	if err != nil {
+		anthropic.WriteError(w, 400, "invalid_request_error", "agentic: "+err.Error())
+		return backend.Result{Status: 400, ErrType: "invalid_request_error"}
+	}
+	n := tokens.ScaleCount(tokens.Estimate(req), tokens.ScaleFactor(call.Route.Model.ContextBudget()))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(anthropic.CountTokensResponse{InputTokens: n})
+	return backend.Result{Status: 200}
+}
+
+// refuse rejects a delegation before any subprocess spawn or stream byte.
+// 400 deliberately (same rationale as the router's budget gate): Claude Code
+// surfaces 400s verbatim instead of retry-spinning, and retrying a
+// side-effectful agent run is worse than retrying a completion.
+func refuse(w http.ResponseWriter, msg string) backend.Result {
+	full := "agentic: " + msg
+	anthropic.WriteError(w, 400, "invalid_request_error", full)
+	return backend.Result{Status: 400, ErrType: "invalid_request_error", ErrMsg: truncate(msg, 512)}
+}
+
+// loginCheck cheaply detects a missing subscription login before spending a
+// subprocess spawn. Heuristic by design: the auth file existing doesn't prove
+// the token is fresh (the CLI itself is the authority and will fail with its
+// own message), but its absence proves login never happened.
+func (b *Backend) loginCheck(dialect string) string {
+	home := b.Home
+	if home == "" {
+		home, _ = os.UserHomeDir()
+	}
+	switch dialect {
+	case config.CLIDialectCodex:
+		dir := os.Getenv("CODEX_HOME")
+		if dir == "" {
+			dir = filepath.Join(home, ".codex")
+		}
+		if _, err := os.Stat(filepath.Join(dir, "auth.json")); err != nil {
+			return "codex CLI is not logged in — run `codex login` (uses your ChatGPT subscription)"
+		}
+	case config.CLIDialectGrok:
+		if os.Getenv("XAI_API_KEY") != "" {
+			return ""
+		}
+		if _, err := os.Stat(filepath.Join(home, ".grok", "auth.json")); err != nil {
+			return "grok CLI is not logged in — run `grok login` (uses your SuperGrok/X Premium+ subscription)"
+		}
+	}
+	return ""
+}
+
+func installHint(dialect string) string {
+	switch dialect {
+	case config.CLIDialectCodex:
+		return "npm install -g @openai/codex"
+	case config.CLIDialectGrok:
+		return "see https://docs.x.ai/build"
+	}
+	return "install the CLI"
+}
+
+// buildArgv shapes the headless invocation per dialect. The task travels as
+// a single argv element — never through a shell.
+func buildArgv(p config.Provider, modelID, task string) []string {
+	switch p.Dialect {
+	case config.CLIDialectCodex:
+		// `codex exec` prints only the final agent message to stdout,
+		// progress to stderr. --skip-git-repo-check: delegations may target
+		// non-git directories.
+		argv := []string{p.Bin(), "exec", "--skip-git-repo-check"}
+		if p.Sandbox != "" {
+			argv = append(argv, "--sandbox", p.Sandbox)
+		}
+		if modelID != "" {
+			argv = append(argv, "-m", modelID)
+		}
+		return append(argv, task)
+	case config.CLIDialectGrok:
+		argv := []string{p.Bin(), "--no-auto-update", "--output-format", "plain"}
+		if modelID != "" {
+			argv = append(argv, "--model", modelID)
+		}
+		return append(argv, "-p", task)
+	}
+	return nil // unreachable: config validation closes the dialect set
+}
+
+// taskText extracts the delegated task from the last user turn: the Task
+// tool sends the task prompt as the sole user message. System prompt and
+// tool definitions are deliberately not forwarded — the peer CLI runs its
+// own harness.
+func taskText(req *anthropic.MessagesRequest) string {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != "user" {
+			continue
+		}
+		out := ""
+		for _, blk := range req.Messages[i].Content {
+			var t string
+			switch blk.Type {
+			case "text":
+				t = blk.Text
+			case "tool_result":
+				t = blk.FlatText()
+			}
+			if t == "" {
+				continue
+			}
+			if out != "" {
+				out += "\n\n"
+			}
+			out += t
+		}
+		if strings.TrimSpace(out) != "" {
+			return out
+		}
+	}
+	return ""
+}
+
+// stdoutText harvests the CLI's answer: trimmed stdout, with a JSON probe
+// (mirrors internal/eval's finalText) as a guard in case a CLI's plain
+// output turns out to wrap JSON.
+func stdoutText(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	if !strings.HasPrefix(s, "{") {
+		return s
+	}
+	var m map[string]any
+	if json.Unmarshal([]byte(s), &m) != nil {
+		return s
+	}
+	for _, key := range []string{"result", "text", "content"} {
+		if v, ok := m[key].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return s
+}
+
+// estimateTokens is the same bytes/4 heuristic internal/tokens uses.
+func estimateTokens(s string) int64 {
+	return int64(len(s)/4) + 1
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+// tailWriter keeps only the last max bytes written — enough stderr to
+// surface a useful error without holding a whole agent run's progress log.
+type tailWriter struct {
+	buf []byte
+	max int
+}
+
+func (t *tailWriter) Write(p []byte) (int, error) {
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.max {
+		t.buf = t.buf[len(t.buf)-t.max:]
+	}
+	return len(p), nil
+}
+
+func (t *tailWriter) String() string {
+	return strings.TrimSpace(string(t.buf))
+}

--- a/internal/backend/clibe/clibe_test.go
+++ b/internal/backend/clibe/clibe_test.go
@@ -1,0 +1,251 @@
+package clibe
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/backend"
+	"github.com/maorbril/agentic/internal/config"
+)
+
+type fakeExecutor struct {
+	dir    string
+	argv   []string
+	stdout string
+	stderr string
+	err    error
+}
+
+func (f *fakeExecutor) Run(_ context.Context, dir string, _ []string, argv []string, _ io.Reader, stdout, stderr io.Writer) error {
+	f.dir = dir
+	f.argv = append([]string(nil), argv...)
+	io.WriteString(stdout, f.stdout)
+	io.WriteString(stderr, f.stderr)
+	return f.err
+}
+
+func testCall(t *testing.T, dir string, p config.Provider, modelID string, stream bool) *backend.Call {
+	t.Helper()
+	raw := []byte(`{"model":"peer","messages":[{"role":"user","content":[{"type":"text","text":"fix the tests"}]}]}`)
+	if stream {
+		raw = []byte(`{"model":"peer","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"fix the tests"}]}]}`)
+	}
+	env, err := anthropic.ParseEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := http.Header{}
+	h.Set(CwdHeader, dir)
+	return &backend.Call{
+		Raw:      raw,
+		Envelope: env,
+		Header:   h,
+		Route: config.Resolved{
+			Alias:    "peer",
+			Provider: p,
+			Model:    config.Model{ID: modelID},
+		},
+	}
+}
+
+func loggedInHome(t *testing.T, dialect string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, "."+dialect)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestMessagesRunsCodexInSessionDirectory(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{stdout: "all fixed\n"}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+		Home:     loggedInHome(t, config.CLIDialectCodex),
+	}
+	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex, Sandbox: "workspace-write"}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, p, "gpt-5", false), rr)
+
+	if res.Status != 200 {
+		t.Fatalf("status = %d, body = %s", res.Status, rr.Body.String())
+	}
+	if exec.dir != dir {
+		t.Errorf("dir = %q, want %q", exec.dir, dir)
+	}
+	want := []string{"codex", "exec", "--skip-git-repo-check", "--sandbox", "workspace-write", "-m", "gpt-5", "fix the tests"}
+	if !reflect.DeepEqual(exec.argv, want) {
+		t.Errorf("argv = %#v, want %#v", exec.argv, want)
+	}
+	if !strings.Contains(rr.Body.String(), `"text":"all fixed"`) {
+		t.Errorf("response missing final output: %s", rr.Body.String())
+	}
+}
+
+func TestMessagesGrokStreamingSequence(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{stdout: `{"result":"done"}`}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/grok", nil },
+		Home:     loggedInHome(t, config.CLIDialectGrok),
+	}
+	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectGrok, Command: "grok-build"}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, p, "grok-4", true), rr)
+
+	if res.Status != 200 {
+		t.Fatalf("status = %d, body = %s", res.Status, rr.Body.String())
+	}
+	want := []string{"grok-build", "--no-auto-update", "--output-format", "plain", "--model", "grok-4", "-p", "fix the tests"}
+	if !reflect.DeepEqual(exec.argv, want) {
+		t.Errorf("argv = %#v, want %#v", exec.argv, want)
+	}
+	body := rr.Body.String()
+	last := -1
+	for _, event := range []string{"message_start", "content_block_start", "content_block_delta", "content_block_stop", "message_delta", "message_stop"} {
+		i := strings.Index(body[last+1:], "event: "+event)
+		if i < 0 {
+			t.Fatalf("missing %s after offset %d:\n%s", event, last, body)
+		}
+		last += i + 1
+	}
+	if !strings.Contains(body, `"text":"done"`) {
+		t.Errorf("stream missing parsed final output: %s", body)
+	}
+}
+
+func TestMessagesFailureIsFinalTextNotErrorEvent(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{stderr: "authentication expired", err: errors.New("exit status 1")}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+		Home:     loggedInHome(t, config.CLIDialectCodex),
+	}
+	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, p, "", true), rr)
+
+	if res.Status != 502 || res.ErrType != "api_error" {
+		t.Fatalf("result = %+v", res)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "event: error") {
+		t.Fatalf("failure must not emit retryable SSE error event:\n%s", body)
+	}
+	if !strings.Contains(body, "authentication expired") || !strings.Contains(body, "event: message_stop") {
+		t.Errorf("failure should be final assistant text: %s", body)
+	}
+}
+
+func TestMessagesNonStreamingFailureUsesHTTPErrorStatus(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{stderr: "bad credentials", err: errors.New("exit status 1")}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+		Home:     loggedInHome(t, config.CLIDialectCodex),
+	}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false), rr)
+	if res.Status != 502 || rr.Code != 502 {
+		t.Fatalf("result status=%d HTTP status=%d body=%s", res.Status, rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "bad credentials") {
+		t.Errorf("body missing failure details: %s", rr.Body.String())
+	}
+}
+
+func TestMessagesRefusesMissingBinaryBeforeExecution(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+		Home:     loggedInHome(t, config.CLIDialectCodex),
+	}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false), rr)
+
+	if res.Status != 400 || !strings.Contains(rr.Body.String(), "npm install -g @openai/codex") {
+		t.Fatalf("result = %+v, body = %s", res, rr.Body.String())
+	}
+	if exec.argv != nil {
+		t.Errorf("executor was invoked: %#v", exec.argv)
+	}
+}
+
+func TestMessagesRefusesMissingWorkingDirectory(t *testing.T) {
+	exec := &fakeExecutor{}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+		Home:     loggedInHome(t, config.CLIDialectCodex),
+	}
+	call := testCall(t, t.TempDir(), config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false)
+	call.Header.Del(CwdHeader)
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), call, rr)
+	if res.Status != 400 || !strings.Contains(rr.Body.String(), CwdHeader) {
+		t.Fatalf("result = %+v, body = %s", res, rr.Body.String())
+	}
+	if exec.argv != nil {
+		t.Errorf("executor was invoked: %#v", exec.argv)
+	}
+}
+
+func TestMessagesRefusesMissingLogin(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/grok", nil },
+		Home:     t.TempDir(),
+	}
+	t.Setenv("XAI_API_KEY", "")
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectGrok}, "", false), rr)
+
+	if res.Status != 400 || !strings.Contains(rr.Body.String(), "grok login") {
+		t.Fatalf("result = %+v, body = %s", res, rr.Body.String())
+	}
+	if exec.argv != nil {
+		t.Errorf("executor was invoked: %#v", exec.argv)
+	}
+}
+
+func TestTaskTextUsesLastUserTurnAndToolResult(t *testing.T) {
+	req, err := anthropic.ParseRequest([]byte(`{
+		"model":"peer",
+		"messages":[
+			{"role":"user","content":"old"},
+			{"role":"assistant","content":"working"},
+			{"role":"user","content":[
+				{"type":"text","text":"new"},
+				{"type":"tool_result","tool_use_id":"x","content":"result"}
+			]}
+		]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := taskText(req); got != "new\n\nresult" {
+		t.Errorf("taskText = %q", got)
+	}
+}

--- a/internal/backend/clibe/clibe_test.go
+++ b/internal/backend/clibe/clibe_test.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/maorbril/agentic/internal/anthropic"
 	"github.com/maorbril/agentic/internal/backend"
@@ -19,17 +21,27 @@ import (
 
 type fakeExecutor struct {
 	dir    string
+	env    []string
 	argv   []string
 	stdout string
 	stderr string
 	err    error
+	block  time.Duration
 }
 
-func (f *fakeExecutor) Run(_ context.Context, dir string, _ []string, argv []string, _ io.Reader, stdout, stderr io.Writer) error {
+func (f *fakeExecutor) Run(ctx context.Context, dir string, env, argv []string, _ io.Reader, stdout, stderr io.Writer) error {
 	f.dir = dir
+	f.env = append([]string(nil), env...)
 	f.argv = append([]string(nil), argv...)
 	io.WriteString(stdout, f.stdout)
 	io.WriteString(stderr, f.stderr)
+	if f.block > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(f.block):
+		}
+	}
 	return f.err
 }
 
@@ -57,26 +69,12 @@ func testCall(t *testing.T, dir string, p config.Provider, modelID string, strea
 	}
 }
 
-func loggedInHome(t *testing.T, dialect string) string {
-	t.Helper()
-	home := t.TempDir()
-	dir := filepath.Join(home, "."+dialect)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte("{}"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return home
-}
-
 func TestMessagesRunsCodexInSessionDirectory(t *testing.T) {
 	dir := t.TempDir()
 	exec := &fakeExecutor{stdout: "all fixed\n"}
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
-		Home:     loggedInHome(t, config.CLIDialectCodex),
 	}
 	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex, Sandbox: "workspace-write"}
 	rr := httptest.NewRecorder()
@@ -103,7 +101,6 @@ func TestMessagesGrokStreamingSequence(t *testing.T) {
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "/usr/bin/grok", nil },
-		Home:     loggedInHome(t, config.CLIDialectGrok),
 	}
 	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectGrok, Command: "grok-build"}
 	rr := httptest.NewRecorder()
@@ -136,13 +133,12 @@ func TestMessagesFailureIsFinalTextNotErrorEvent(t *testing.T) {
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
-		Home:     loggedInHome(t, config.CLIDialectCodex),
 	}
 	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}
 	rr := httptest.NewRecorder()
 	res := b.Messages(context.Background(), testCall(t, dir, p, "", true), rr)
 
-	if res.Status != 502 || res.ErrType != "api_error" {
+	if res.Status != 200 || res.ErrType != "api_error" {
 		t.Fatalf("result = %+v", res)
 	}
 	body := rr.Body.String()
@@ -154,18 +150,20 @@ func TestMessagesFailureIsFinalTextNotErrorEvent(t *testing.T) {
 	}
 }
 
-func TestMessagesNonStreamingFailureUsesHTTPErrorStatus(t *testing.T) {
+func TestMessagesNonStreamingFailureIsHTTP200(t *testing.T) {
 	dir := t.TempDir()
 	exec := &fakeExecutor{stderr: "bad credentials", err: errors.New("exit status 1")}
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
-		Home:     loggedInHome(t, config.CLIDialectCodex),
 	}
 	rr := httptest.NewRecorder()
 	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false), rr)
-	if res.Status != 502 || rr.Code != 502 {
+	if res.Status != 200 || rr.Code != 200 {
 		t.Fatalf("result status=%d HTTP status=%d body=%s", res.Status, rr.Code, rr.Body.String())
+	}
+	if res.ErrType != "api_error" {
+		t.Errorf("log result should still record the failure: %+v", res)
 	}
 	if !strings.Contains(rr.Body.String(), "bad credentials") {
 		t.Errorf("body missing failure details: %s", rr.Body.String())
@@ -178,7 +176,6 @@ func TestMessagesRefusesMissingBinaryBeforeExecution(t *testing.T) {
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "", errors.New("not found") },
-		Home:     loggedInHome(t, config.CLIDialectCodex),
 	}
 	rr := httptest.NewRecorder()
 	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false), rr)
@@ -196,7 +193,6 @@ func TestMessagesRefusesMissingWorkingDirectory(t *testing.T) {
 	b := &Backend{
 		Exec:     exec,
 		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
-		Home:     loggedInHome(t, config.CLIDialectCodex),
 	}
 	call := testCall(t, t.TempDir(), config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false)
 	call.Header.Del(CwdHeader)
@@ -210,23 +206,108 @@ func TestMessagesRefusesMissingWorkingDirectory(t *testing.T) {
 	}
 }
 
-func TestMessagesRefusesMissingLogin(t *testing.T) {
+func TestMessagesRefusesOversizedTask(t *testing.T) {
 	dir := t.TempDir()
 	exec := &fakeExecutor{}
 	b := &Backend{
 		Exec:     exec,
-		LookPath: func(string) (string, error) { return "/usr/bin/grok", nil },
-		Home:     t.TempDir(),
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
 	}
-	t.Setenv("XAI_API_KEY", "")
+	task := strings.Repeat("x", maxTaskBytes+1)
+	raw := []byte(`{"model":"peer","messages":[{"role":"user","content":[{"type":"text","text":"` + task + `"}]}]}`)
+	env, err := anthropic.ParseEnvelope(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := http.Header{}
+	h.Set(CwdHeader, dir)
+	call := &backend.Call{
+		Raw: raw, Envelope: env, Header: h,
+		Route: config.Resolved{Alias: "peer", Provider: config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}},
+	}
 	rr := httptest.NewRecorder()
-	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectGrok}, "", false), rr)
-
-	if res.Status != 400 || !strings.Contains(rr.Body.String(), "grok login") {
+	res := b.Messages(context.Background(), call, rr)
+	if res.Status != 400 || !strings.Contains(rr.Body.String(), "keep it under") {
 		t.Fatalf("result = %+v, body = %s", res, rr.Body.String())
 	}
 	if exec.argv != nil {
 		t.Errorf("executor was invoked: %#v", exec.argv)
+	}
+}
+
+func TestMessagesStripsRouterSecretsFromDelegatedEnv(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{stdout: "ok"}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+		Environ: func() []string {
+			return []string{
+				"PATH=/usr/bin",
+				"ANTHROPIC_AUTH_TOKEN=secret",
+				"ANTHROPIC_BASE_URL=http://127.0.0.1:41100",
+				"ANTHROPIC_CUSTOM_HEADERS=X-Agentic-Session: x",
+				"OPENAI_API_KEY=sk-test",
+				"CODEX_HOME=/tmp/codex",
+			}
+		},
+	}
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex}, "", false), rr)
+	if res.Status != 200 {
+		t.Fatalf("status = %d body=%s", res.Status, rr.Body.String())
+	}
+	joined := strings.Join(exec.env, "\n")
+	for _, secret := range []string{"ANTHROPIC_AUTH_TOKEN=", "ANTHROPIC_BASE_URL=", "ANTHROPIC_CUSTOM_HEADERS=", "OPENAI_API_KEY="} {
+		if strings.Contains(joined, secret) {
+			t.Errorf("delegated env leaked %s: %v", secret, exec.env)
+		}
+	}
+	if !strings.Contains(joined, "PATH=/usr/bin") || !strings.Contains(joined, "CODEX_HOME=/tmp/codex") {
+		t.Errorf("delegated env dropped required values: %v", exec.env)
+	}
+}
+
+func TestMessagesTimeoutCancelsBlockedExecutor(t *testing.T) {
+	dir := t.TempDir()
+	exec := &fakeExecutor{block: 20 * time.Second}
+	b := &Backend{
+		Exec:     exec,
+		LookPath: func(string) (string, error) { return "/usr/bin/codex", nil },
+	}
+	p := config.Provider{Type: config.ProviderCLI, Dialect: config.CLIDialectCodex, TimeoutMS: 50}
+	start := time.Now()
+	rr := httptest.NewRecorder()
+	res := b.Messages(context.Background(), testCall(t, dir, p, "", false), rr)
+	if time.Since(start) > 5*time.Second {
+		t.Fatalf("timeout waited too long: %s", time.Since(start))
+	}
+	if res.Status != 200 || res.ErrType != "api_error" || !strings.Contains(rr.Body.String(), "timed out") {
+		t.Fatalf("result = %+v body=%s", res, rr.Body.String())
+	}
+}
+
+func TestOSExecutorKillsProcessGroup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("process groups are unix-only")
+	}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "still-running")
+	script := filepath.Join(dir, "hang.sh")
+	body := "#!/bin/sh\n(while true; do touch '" + marker + "'; sleep 0.1; done) &\nwait\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	err := OSExecutor{}.Run(ctx, dir, os.Environ(), []string{script}, nil, io.Discard, io.Discard)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Run err = %v, want deadline", err)
+	}
+	os.Remove(marker)
+	time.Sleep(400 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("descendant kept writing after cancellation")
 	}
 }
 

--- a/internal/backend/clibe/exec_unix.go
+++ b/internal/backend/clibe/exec_unix.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package clibe
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func isolateProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func killProcessTree(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	// Negative PID = the process group started by isolateProcess.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/backend/clibe/exec_windows.go
+++ b/internal/backend/clibe/exec_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package clibe
+
+import "os/exec"
+
+func isolateProcess(*exec.Cmd) {}
+
+func killProcessTree(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,16 @@ import (
 const (
 	ProviderAnthropic = "anthropic"
 	ProviderOpenAI    = "openai"
+	// ProviderCLI delegates to a locally installed coding-agent CLI (Codex,
+	// Grok Build) running under the user's own subscription login, instead of
+	// an HTTP endpoint. agentic never touches the CLI's credentials — the
+	// binary authenticates itself from its own cached login.
+	ProviderCLI = "cli"
+
+	// CLI dialects — a closed set because the dialect determines argv shape,
+	// how the task text is passed, output extraction, and the login preflight.
+	CLIDialectCodex = "codex" // OpenAI Codex CLI: `codex exec`
+	CLIDialectGrok  = "grok"  // xAI Grok Build CLI: `grok -p`
 
 	DefaultPort = 41100
 )
@@ -76,7 +86,7 @@ type Router struct {
 }
 
 type Provider struct {
-	Type      string `yaml:"type"` // "anthropic" | "openai"
+	Type      string `yaml:"type"` // "anthropic" | "openai" | "cli"
 	BaseURL   string `yaml:"base_url"`
 	APIKeyEnv string `yaml:"api_key_env"`
 	APIKey    string `yaml:"api_key"`
@@ -89,6 +99,29 @@ type Provider struct {
 	// 0 means unknown/no cap. Sits on the provider because the cap belongs to
 	// the upstream edge, not the model.
 	MaxRequestBytes int `yaml:"max_request_bytes"`
+
+	// Dialect selects which coding-agent CLI a "cli" provider shells out to:
+	// CLIDialectCodex or CLIDialectGrok. cli providers only.
+	Dialect string `yaml:"dialect"`
+	// Command overrides the CLI binary name or path. Empty defaults to the
+	// dialect name ("codex"/"grok"). cli providers only.
+	Command string `yaml:"command"`
+	// Sandbox is passed through to Codex as --sandbox (read-only |
+	// workspace-write | danger-full-access). codex dialect only; empty keeps
+	// the CLI's own default.
+	Sandbox string `yaml:"sandbox"`
+	// TimeoutMS bounds a single delegated CLI run. 0 means the built-in
+	// default (20 minutes). cli providers only.
+	TimeoutMS int `yaml:"timeout_ms"`
+}
+
+// Bin returns the CLI binary to invoke for a cli provider: the configured
+// Command, else the dialect name.
+func (p Provider) Bin() string {
+	if p.Command != "" {
+		return p.Command
+	}
+	return p.Dialect
 }
 
 // Key resolves the provider's API key: config literal, then process
@@ -236,12 +269,41 @@ func (c *Config) Validate() error {
 	for name, p := range c.Providers {
 		switch p.Type {
 		case ProviderAnthropic, ProviderOpenAI:
+			if p.BaseURL == "" {
+				return fmt.Errorf("config: provider %q missing base_url", name)
+			}
+			// Catch cli-only fields here instead of silently ignoring them.
+			if p.Dialect != "" || p.Command != "" || p.Sandbox != "" || p.TimeoutMS != 0 {
+				return fmt.Errorf("config: provider %q: dialect/command/sandbox/timeout_ms only apply to cli providers — remove them", name)
+			}
+		case ProviderCLI:
+			switch p.Dialect {
+			case CLIDialectCodex, CLIDialectGrok:
+			default:
+				return fmt.Errorf("config: provider %q has unknown dialect %q (want %q or %q)",
+					name, p.Dialect, CLIDialectCodex, CLIDialectGrok)
+			}
+			// A cli provider has no HTTP upstream; these would be silently
+			// ignored, which is the failure mode this switch guards against.
+			if p.BaseURL != "" || p.APIKey != "" || p.APIKeyEnv != "" || p.MaxTokensParam != "" || p.MaxRequestBytes != 0 {
+				return fmt.Errorf("config: provider %q: base_url/api_key/api_key_env/max_tokens_param/max_request_bytes have no effect on cli providers — remove them", name)
+			}
+			if p.Sandbox != "" {
+				if p.Dialect != CLIDialectCodex {
+					return fmt.Errorf("config: provider %q: sandbox only applies to the %q dialect", name, CLIDialectCodex)
+				}
+				switch p.Sandbox {
+				case "read-only", "workspace-write", "danger-full-access":
+				default:
+					return fmt.Errorf("config: provider %q has unknown sandbox %q (want read-only, workspace-write, or danger-full-access)", name, p.Sandbox)
+				}
+			}
+			if p.TimeoutMS < 0 {
+				return fmt.Errorf("config: provider %q has negative timeout_ms", name)
+			}
 		default:
-			return fmt.Errorf("config: provider %q has unknown type %q (want %q or %q)",
-				name, p.Type, ProviderAnthropic, ProviderOpenAI)
-		}
-		if p.BaseURL == "" {
-			return fmt.Errorf("config: provider %q missing base_url", name)
+			return fmt.Errorf("config: provider %q has unknown type %q (want %q, %q, or %q)",
+				name, p.Type, ProviderAnthropic, ProviderOpenAI, ProviderCLI)
 		}
 		if p.MaxRequestBytes < 0 {
 			return fmt.Errorf("config: provider %q has negative max_request_bytes", name)
@@ -250,6 +312,15 @@ func (c *Config) Validate() error {
 	for alias, m := range c.Models {
 		if _, ok := c.Providers[m.Provider]; !ok {
 			return fmt.Errorf("config: model %q references unknown provider %q", alias, m.Provider)
+		}
+		if c.Providers[m.Provider].Type == ProviderCLI {
+			// A delegated CLI run is a whole agent loop, not a completion —
+			// none of the HTTP/completion knobs apply. ID stays optional and,
+			// when set, is passed as the CLI's model-selection flag.
+			if m.Reasoning != "" || m.MaxOutput != 0 || m.Pricing != nil || m.ContextWindow != 0 || m.EffectiveContext != 0 {
+				return fmt.Errorf("config: model %q: reasoning/max_output/pricing/context_window/effective_context have no effect on cli providers — remove them", alias)
+			}
+			continue
 		}
 		if m.ID == "" {
 			return fmt.Errorf("config: model %q missing id", alias)
@@ -283,10 +354,16 @@ func (c *Config) Validate() error {
 			if !c.isModelRef(alias) {
 				return fmt.Errorf("config: profile %q %s references unknown model alias %q", name, what, alias)
 			}
+			if c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: profile %q %s references cli alias %q — cli delegation is only available as an explicit subagent (agentic agents sync), not a session model", name, what, alias)
+			}
 		}
 		for tier, alias := range prof.Tiers {
 			if !c.isModelRef(alias) {
 				return fmt.Errorf("config: profile %q tier %q references unknown model alias %q", name, tier, alias)
+			}
+			if c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: profile %q tier %q references cli alias %q — cli delegation is only available as an explicit subagent, not a tier fallback", name, tier, alias)
 			}
 		}
 		if prof.PinTiers && prof.Model == "" {
@@ -305,12 +382,18 @@ func (c *Config) Validate() error {
 		if _, ok := c.Models[r.Classifier]; !ok {
 			return fmt.Errorf("config: routing %q classifier references unknown model alias %q", name, r.Classifier)
 		}
+		if c.IsCLIAlias(r.Classifier) {
+			return fmt.Errorf("config: routing %q classifier %q is a cli alias — classification needs a completion model, not a delegated agent", name, r.Classifier)
+		}
 		if len(r.Tiers) == 0 {
 			return fmt.Errorf("config: routing %q has no tiers", name)
 		}
 		for tier, alias := range r.Tiers {
 			if _, ok := c.Models[alias]; !ok {
 				return fmt.Errorf("config: routing %q tier %q references unknown model alias %q", name, tier, alias)
+			}
+			if c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: routing %q tier %q references cli alias %q — auto-routing must never silently start a delegated agent run; invoke it as an explicit subagent instead", name, tier, alias)
 			}
 		}
 		if r.Default != "" {
@@ -326,6 +409,9 @@ func (c *Config) Validate() error {
 			if _, ok := c.Models[alias]; !ok {
 				return fmt.Errorf("config: routing %q task %q references unknown model alias %q", name, label, alias)
 			}
+			if c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: routing %q task %q references cli alias %q — auto-routing must never silently start a delegated agent run; invoke it as an explicit subagent instead", name, label, alias)
+			}
 		}
 	}
 	return nil
@@ -340,6 +426,17 @@ func (c *Config) isModelRef(name string) bool {
 	}
 	_, ok := c.Routing[name]
 	return ok
+}
+
+// IsCLIAlias reports whether name is a model alias backed by a cli provider —
+// i.e. one that delegates a whole task to a local coding-agent CLI instead of
+// answering a single completion.
+func (c *Config) IsCLIAlias(name string) bool {
+	m, ok := c.Models[name]
+	if !ok {
+		return false
+	}
+	return c.Providers[m.Provider].Type == ProviderCLI
 }
 
 // Resolved is a model alias resolved to its provider.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ const (
 	ProviderCLI = "cli"
 
 	// CLI dialects — a closed set because the dialect determines argv shape,
-	// how the task text is passed, output extraction, and the login preflight.
+	// how the task text is passed, and output extraction.
 	CLIDialectCodex = "codex" // OpenAI Codex CLI: `codex exec`
 	CLIDialectGrok  = "grok"  // xAI Grok Build CLI: `grok -p`
 
@@ -344,6 +344,16 @@ func (c *Config) Validate() error {
 		}
 	}
 	for name, prof := range c.Profiles {
+		for what, alias := range map[string]string{"model": prof.Model, "small_fast": prof.SmallFast} {
+			if alias != "" && c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: profile %q %s references cli alias %q — cli delegation is only available as an explicit subagent (agentic agents sync), not a session model", name, what, alias)
+			}
+		}
+		for tier, alias := range prof.Tiers {
+			if c.IsCLIAlias(alias) {
+				return fmt.Errorf("config: profile %q tier %q references cli alias %q — cli delegation is only available as an explicit subagent, not a tier fallback", name, tier, alias)
+			}
+		}
 		if prof.Passthrough {
 			continue
 		}
@@ -354,16 +364,10 @@ func (c *Config) Validate() error {
 			if !c.isModelRef(alias) {
 				return fmt.Errorf("config: profile %q %s references unknown model alias %q", name, what, alias)
 			}
-			if c.IsCLIAlias(alias) {
-				return fmt.Errorf("config: profile %q %s references cli alias %q — cli delegation is only available as an explicit subagent (agentic agents sync), not a session model", name, what, alias)
-			}
 		}
 		for tier, alias := range prof.Tiers {
 			if !c.isModelRef(alias) {
 				return fmt.Errorf("config: profile %q tier %q references unknown model alias %q", name, tier, alias)
-			}
-			if c.IsCLIAlias(alias) {
-				return fmt.Errorf("config: profile %q tier %q references cli alias %q — cli delegation is only available as an explicit subagent, not a tier fallback", name, tier, alias)
 			}
 		}
 		if prof.PinTiers && prof.Model == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -148,6 +148,11 @@ providers: {p: {type: cli, dialect: codex}}
 models: {m: {provider: p}}
 profiles: {main: {model: m}}
 `,
+		"cli alias on passthrough profile": `
+providers: {p: {type: cli, dialect: codex}}
+models: {m: {provider: p}}
+profiles: {sub: {passthrough: true, model: m}}
+`,
 		"cli alias as classifier": `
 providers:
   p: {type: cli, dialect: codex}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,6 +108,79 @@ profiles:
 	}
 }
 
+func TestCLIProviderValidation(t *testing.T) {
+	valid := `
+providers:
+  codex: {type: cli, dialect: codex, sandbox: workspace-write, timeout_ms: 60000}
+  grok: {type: cli, dialect: grok, command: /opt/bin/grok}
+models:
+  codex: {provider: codex}
+  grok-fast: {provider: grok, id: grok-code-fast}
+`
+	cfg, err := Parse([]byte(valid))
+	if err != nil {
+		t.Fatalf("valid cli config rejected: %v", err)
+	}
+	if cfg.Providers["codex"].Bin() != "codex" || cfg.Providers["grok"].Bin() != "/opt/bin/grok" {
+		t.Errorf("unexpected binaries: codex=%q grok=%q", cfg.Providers["codex"].Bin(), cfg.Providers["grok"].Bin())
+	}
+	if !cfg.IsCLIAlias("codex") || cfg.IsCLIAlias("missing") {
+		t.Errorf("IsCLIAlias returned unexpected result")
+	}
+
+	cases := map[string]string{
+		"missing dialect":        `providers: {p: {type: cli}}`,
+		"unknown dialect":        `providers: {p: {type: cli, dialect: gemini}}`,
+		"base url forbidden":     `providers: {p: {type: cli, dialect: codex, base_url: http://x}}`,
+		"grok sandbox forbidden": `providers: {p: {type: cli, dialect: grok, sandbox: workspace-write}}`,
+		"invalid codex sandbox":  `providers: {p: {type: cli, dialect: codex, sandbox: unrestricted}}`,
+		"negative timeout":       `providers: {p: {type: cli, dialect: codex, timeout_ms: -1}}`,
+		"cli model pricing forbidden": `
+providers: {p: {type: cli, dialect: codex}}
+models: {m: {provider: p, pricing: {input: 1, output: 1}}}
+`,
+		"cli model context forbidden": `
+providers: {p: {type: cli, dialect: codex}}
+models: {m: {provider: p, context_window: 200000}}
+`,
+		"cli alias as profile model": `
+providers: {p: {type: cli, dialect: codex}}
+models: {m: {provider: p}}
+profiles: {main: {model: m}}
+`,
+		"cli alias as classifier": `
+providers:
+  p: {type: cli, dialect: codex}
+  a: {type: anthropic, base_url: https://api.anthropic.com}
+models:
+  m: {provider: p}
+  sonnet: {provider: a, id: claude-sonnet-5}
+routing:
+  auto: {classifier: m, tiers: {standard: sonnet}}
+`,
+		"cli alias as task target": `
+providers:
+  p: {type: cli, dialect: codex}
+  a: {type: anthropic, base_url: https://api.anthropic.com}
+models:
+  m: {provider: p}
+  sonnet: {provider: a, id: claude-sonnet-5}
+routing:
+  auto:
+    classifier: sonnet
+    tiers: {standard: sonnet}
+    tasks: {implementation: m}
+`,
+	}
+	for name, yaml := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(yaml)); err == nil {
+				t.Error("expected validation error")
+			}
+		})
+	}
+}
+
 func TestTaskRoutingValidation(t *testing.T) {
 	base := `
 providers:

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -91,6 +91,9 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 
 		model := prof.Model
 		if opts.ModelFlag != "" {
+			if cfg.IsCLIAlias(opts.ModelFlag) {
+				return fmt.Errorf("cli alias %q is only available as an explicit subagent (agentic-%s), not a session model", opts.ModelFlag, opts.ModelFlag)
+			}
 			model = opts.ModelFlag
 		}
 		cwd, _ := os.Getwd()

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -93,7 +93,8 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 		if opts.ModelFlag != "" {
 			model = opts.ModelFlag
 		}
-		env = sessionEnv(env, mgr.BaseURL(), token, sessionID, profName, prof, model)
+		cwd, _ := os.Getwd()
+		env = sessionEnv(env, mgr.BaseURL(), token, sessionID, profName, prof, model, cwd)
 
 		recordSession(dataDir, sessionID, profName, true)
 		defer func() {
@@ -135,15 +136,24 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 // sessionEnv assembles the child process environment for a non-passthrough
 // profile: router creds, model selection, and the X-Agentic-* headers Claude
 // Code carries transparently on every request so the router can attribute
-// spend to this session and (when pinned) enforce the pin. Extracted from
-// Run so PinTiers behavior is directly testable without spawning a router
-// or a claude process.
-func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof config.Profile, model string) []string {
+// spend to this session and (when pinned) enforce the pin. cwd rides along as
+// X-Agentic-Cwd so cli-delegation backends run the peer CLI in the session's
+// directory (the router leader is a shared long-lived process whose own cwd
+// is meaningless). Extracted from Run so PinTiers behavior is directly
+// testable without spawning a router or a claude process.
+func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof config.Profile, model, cwd string) []string {
 	env = setEnv(env, "ANTHROPIC_BASE_URL", baseURL)
 	env = setEnv(env, "ANTHROPIC_AUTH_TOKEN", token)
 	env = unsetEnv(env, "ANTHROPIC_API_KEY")
 	if model != "" {
 		env = setEnv(env, "ANTHROPIC_MODEL", model)
+	}
+	// Header values must be single-line; a pathological cwd must not let one
+	// header smuggle another.
+	cwd = strings.NewReplacer("\n", "", "\r", "").Replace(cwd)
+	cwdHeader := ""
+	if cwd != "" {
+		cwdHeader = "\nX-Agentic-Cwd: " + cwd
 	}
 	if prof.PinTiers && model != "" {
 		// Pin every tier fallback — including Claude Code's own subagent
@@ -157,7 +167,7 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 		env = setEnv(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL", model)
 		env = setEnv(env, "CLAUDE_CODE_SUBAGENT_MODEL", model)
 		env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS",
-			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s\nX-Agentic-Pin-Model: %s", sessionID, profName, model))
+			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s\nX-Agentic-Pin-Model: %s%s", sessionID, profName, model, cwdHeader))
 	} else {
 		if prof.SmallFast != "" {
 			env = setEnv(env, "ANTHROPIC_SMALL_FAST_MODEL", prof.SmallFast)
@@ -166,7 +176,7 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 			env = setEnv(env, "ANTHROPIC_DEFAULT_"+strings.ToUpper(tier)+"_MODEL", alias)
 		}
 		env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS",
-			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s", sessionID, profName))
+			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s%s", sessionID, profName, cwdHeader))
 	}
 	env = setEnv(env, "AGENTIC_SESSION_ID", sessionID)
 	env = setEnv(env, "AGENTIC_PROFILE", profName)

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -27,7 +27,7 @@ func TestSessionEnvWithoutPinTiers(t *testing.T) {
 		SmallFast: "haiku",
 		Tiers:     map[string]string{"opus": "opus", "sonnet": "sonnet", "haiku": "haiku"},
 	}
-	env := sessionEnv(nil, "http://127.0.0.1:41100", "tok", "sess-1", "main", prof, prof.Model)
+	env := sessionEnv(nil, "http://127.0.0.1:41100", "tok", "sess-1", "main", prof, prof.Model, "/tmp/project")
 
 	if got := envVal(env, "ANTHROPIC_MODEL"); got != "gpt-5.6-sol" {
 		t.Errorf("ANTHROPIC_MODEL = %q, want gpt-5.6-sol", got)
@@ -45,6 +45,9 @@ func TestSessionEnvWithoutPinTiers(t *testing.T) {
 	if strings.Contains(headers, "X-Agentic-Pin-Model") {
 		t.Errorf("custom headers should not carry a pin when pin_tiers is off: %q", headers)
 	}
+	if !strings.Contains(headers, "X-Agentic-Cwd: /tmp/project") {
+		t.Errorf("custom headers missing session cwd: %q", headers)
+	}
 }
 
 // With pin_tiers, every tier fallback — including Claude Code's own subagent
@@ -57,7 +60,7 @@ func TestSessionEnvWithPinTiers(t *testing.T) {
 		Tiers:     map[string]string{"opus": "opus", "sonnet": "sonnet"}, // must be overridden
 		PinTiers:  true,
 	}
-	env := sessionEnv(nil, "http://127.0.0.1:41100", "tok", "sess-1", "main", prof, prof.Model)
+	env := sessionEnv(nil, "http://127.0.0.1:41100", "tok", "sess-1", "main", prof, prof.Model, "/tmp/project")
 
 	for _, key := range []string{
 		"ANTHROPIC_SMALL_FAST_MODEL",

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -348,6 +348,9 @@ func (s *Server) runClassifier(ctx context.Context, rule config.RouteRule, cfg *
 	case config.ProviderOpenAI:
 		be = s.oai
 	default:
+		// Deliberately narrower than handleMessages' dispatch: config
+		// validation forbids cli-type aliases as classifiers, so this
+		// error is the backstop, not a missing case.
 		return nil, fmt.Errorf("classifier provider type %q unsupported", route.Provider.Type)
 	}
 	res := be.Messages(ctx, call, rec)

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/maorbril/agentic/internal/anthropic"
 	"github.com/maorbril/agentic/internal/backend"
 	"github.com/maorbril/agentic/internal/backend/anthropicbe"
+	"github.com/maorbril/agentic/internal/backend/clibe"
 	"github.com/maorbril/agentic/internal/backend/openaibe"
 	"github.com/maorbril/agentic/internal/budget"
 	"github.com/maorbril/agentic/internal/config"
@@ -31,6 +32,7 @@ type Server struct {
 	store   *store.Store
 	anth    *anthropicbe.Backend
 	oai     *openaibe.Backend
+	cli     *clibe.Backend
 	gate    *budget.Gate
 	auto    *autoRouter
 	goal    *goalRouter
@@ -40,7 +42,7 @@ type Server struct {
 func NewServer(cfg *config.Config, token, dataDir string, st *store.Store, logger *slog.Logger) *Server {
 	s := &Server{
 		token: token, dataDir: dataDir, store: st,
-		anth: anthropicbe.New(), oai: openaibe.New(), log: logger,
+		anth: anthropicbe.New(), oai: openaibe.New(), cli: clibe.New(), log: logger,
 	}
 	s.cfg.Store(cfg)
 	s.pricing.Store(pricing.Load(dataDir, cfg))
@@ -204,7 +206,10 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 		}
 
 		profile := r.Header.Get("X-Agentic-Profile")
-		if !countTokens {
+		if !countTokens && route.Provider.Type != config.ProviderCLI {
+			// CLI delegation spends against the peer CLI's subscription, outside
+			// agentic's pricing data. A $0 API budget must not block capacity it
+			// neither meters nor pays for.
 			if msg := s.gate.Check(profile); msg != "" {
 				// 400 deliberately — 429/5xx would make Claude Code retry-spin;
 				// a 400 surfaces the message verbatim in the TUI.
@@ -220,6 +225,8 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 			be = s.anth
 		case config.ProviderOpenAI:
 			be = s.oai
+		case config.ProviderCLI:
+			be = s.cli
 		default:
 			anthropic.WriteError(w, 501, "api_error",
 				fmt.Sprintf("agentic: provider type %q not implemented (model %q)", route.Provider.Type, env.Model))
@@ -245,6 +252,11 @@ func (s *Server) recordUsage(r *http.Request, route config.Resolved, alias strin
 	}
 	cost, priced := s.pricing.Load().Cost(route.Model.ID,
 		u.InputTokens, u.OutputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens)
+	if route.Provider.Type == config.ProviderCLI {
+		// Even when the optional CLI model ID happens to match an entry in the
+		// API price table, subscription spend is opaque to agentic.
+		cost, priced = 0, false
+	}
 	budget := route.Model.ContextBudget()
 	ev := store.UsageEvent{
 		TS:               time.Now(),

--- a/internal/router/server_test.go
+++ b/internal/router/server_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/maorbril/agentic/internal/backend"
 	"github.com/maorbril/agentic/internal/config"
 	"github.com/maorbril/agentic/internal/store"
 )
@@ -113,6 +115,122 @@ func TestOpenAIStreamThroughRouter(t *testing.T) {
 	}
 	if rows[0].Key != "sess-test" || rows[0].InputTokens != 11 || rows[0].OutputTokens != 3 {
 		t.Errorf("usage row: %+v", rows[0])
+	}
+}
+
+func TestCLIProviderDispatchesThroughRouter(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"codex": {Type: config.ProviderCLI, Dialect: config.CLIDialectCodex},
+		},
+		Models: map[string]config.Model{
+			"codex": {Provider: "codex"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv.cli.LookPath = func(string) (string, error) { return "", fmt.Errorf("not installed") }
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(
+		`{"model":"codex","messages":[{"role":"user","content":"fix it"}]}`))
+	req.Header.Set("x-api-key", testToken)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("X-Agentic-Cwd", t.TempDir())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "Codex") && !strings.Contains(string(body), "codex") {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "not found on PATH") {
+		t.Errorf("cli backend refusal missing from router response: %s", body)
+	}
+}
+
+func TestCLIUsageStaysUnpricedWhenModelIDHasAPIPrice(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"codex": {Type: config.ProviderCLI, Dialect: config.CLIDialectCodex},
+		},
+		Models: map[string]config.Model{
+			"codex": {Provider: "codex", ID: "claude-sonnet-5"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv.recordUsage(httptest.NewRequest(http.MethodPost, "/v1/messages", nil), config.Resolved{
+		Alias: "codex", ProviderName: "codex", Provider: cfg.Providers["codex"], Model: cfg.Models["codex"],
+	}, "codex", backend.Result{Status: 200, Usage: anthropic.Usage{InputTokens: 1000, OutputTokens: 1000}}, time.Millisecond)
+
+	rows, err := st.SpendSince(time.Now().Add(-time.Minute), "model")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("rows=%v err=%v", rows, err)
+	}
+	if rows[0].CostUSD != 0 || rows[0].Unpriced != 1 {
+		t.Errorf("CLI subscription usage must remain unpriced: %+v", rows[0])
+	}
+}
+
+func TestCLIDelegationBypassesAPIBudgetGate(t *testing.T) {
+	dir := t.TempDir()
+	hardStop := true
+	cfg := &config.Config{
+		Providers: map[string]config.Provider{
+			"codex": {Type: config.ProviderCLI, Dialect: config.CLIDialectCodex},
+		},
+		Models:  map[string]config.Model{"codex": {Provider: "codex"}},
+		Budgets: &config.Budget{Daily: 0.01, HardStop: &hardStop},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.Open(filepath.Join(dir, "agentic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.RecordUsage(store.UsageEvent{TS: time.Now(), CostUSD: 1, Priced: true}); err != nil {
+		t.Fatal(err)
+	}
+	srv := NewServer(cfg, testToken, dir, st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv.cli.LookPath = func(string) (string, error) { return "", fmt.Errorf("not installed") }
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages", strings.NewReader(
+		`{"model":"codex","messages":[{"role":"user","content":"fix it"}]}`))
+	req.Header.Set("x-api-key", testToken)
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("X-Agentic-Cwd", t.TempDir())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if strings.Contains(string(body), "budget exceeded") || !strings.Contains(string(body), "not found on PATH") {
+		t.Fatalf("CLI request should reach CLI backend despite API budget: status=%d body=%s", resp.StatusCode, body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `cli` providers that delegate explicit whole-task subagents to the official local Codex or Grok CLI under each user's own subscription login
- keep vendor OAuth credentials inside the vendor CLI; agentic only executes the binary with a single task argv and validated session cwd
- add retry-safe Anthropic JSON/SSE adaptation, timeouts, unpriced usage visibility, API-budget bypass, CLI configuration commands, generated-agent guidance, validation, and docs

## Safety and scope

- delegation is explicit-only: CLI aliases are rejected as profile models, tier fallbacks, classifiers, and task mappings
- failures never emit retryable SSE error events, avoiding duplicate filesystem-mutating runs
- no subscription sharing, credential extraction, or credential proxying
- no conversation/system/tool forwarding: the peer CLI receives only the self-contained task prompt
- no incremental peer-CLI output; the final CLI message is returned after completion

## Testing

- `go test -race ./internal/backend/clibe ./internal/router ./internal/config ./internal/launch ./internal/agents ./cmd`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- temporary-HOME smoke test: provider/model creation, generated agent sync, and explicit `models test codex` missing-binary 400 refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)