### PR TITLE
openaibe: split assistant tool_calls exceeding OpenAI's 128 limit

### DIFF
--- a/internal/backend/openaibe/request.go
+++ b/internal/backend/openaibe/request.go
@@ -10,6 +10,13 @@ import (
 	"github.com/maorbril/agentic/internal/openai"
 )
 
+// maxToolCallsPerMessage is OpenAI's hard cap on messages[].tool_calls
+// length. Claude Code can emit a single assistant turn with more tool_use
+// blocks than that (e.g. after context compaction); translateMessage splits
+// the excess into extra assistant messages rather than sending an
+// oversized array.
+const maxToolCallsPerMessage = 128
+
 // TranslateRequest maps an Anthropic request onto a ChatRequest. Fidelity
 // gaps (documented in the README): cache_control stripped, server tools
 // dropped, thinking blocks not round-tripped, top_k dropped, stop
@@ -126,7 +133,7 @@ func translateMessage(msg anthropic.Message) ([]openai.ChatMessage, error) {
 		return []openai.ChatMessage{{Role: "system", Content: text}}, nil
 
 	case "assistant":
-		out := openai.ChatMessage{Role: "assistant"}
+		var toolCalls []openai.ToolCall
 		text := ""
 		for _, b := range msg.Content {
 			switch b.Type {
@@ -136,7 +143,7 @@ func translateMessage(msg anthropic.Message) ([]openai.ChatMessage, error) {
 				}
 				text += b.Text
 			case "tool_use":
-				out.ToolCalls = append(out.ToolCalls, openai.ToolCall{
+				toolCalls = append(toolCalls, openai.ToolCall{
 					ID:       b.ID,
 					Type:     "function",
 					Function: openai.FunctionCall{Name: b.Name, Arguments: string(b.Input)},
@@ -145,13 +152,31 @@ func translateMessage(msg anthropic.Message) ([]openai.ChatMessage, error) {
 				// Dropped on resend — no OpenAI slot, and DeepSeek requires omitting it.
 			}
 		}
-		if text != "" {
-			out.Content = text
-		}
-		if out.Content == nil && len(out.ToolCalls) == 0 {
+		if text == "" && len(toolCalls) == 0 {
 			return nil, nil
 		}
-		return []openai.ChatMessage{out}, nil
+		if len(toolCalls) <= maxToolCallsPerMessage {
+			out := openai.ChatMessage{Role: "assistant", ToolCalls: toolCalls}
+			if text != "" {
+				out.Content = text
+			}
+			return []openai.ChatMessage{out}, nil
+		}
+		// A single Anthropic turn can carry more tool_use blocks than
+		// OpenAI's hard cap on messages[].tool_calls (128); split the
+		// excess into additional assistant messages. The tool results for
+		// all of them still arrive in the next Anthropic message and land
+		// right after, so ordering holds.
+		var out []openai.ChatMessage
+		for i := 0; i < len(toolCalls); i += maxToolCallsPerMessage {
+			end := min(i+maxToolCallsPerMessage, len(toolCalls))
+			m := openai.ChatMessage{Role: "assistant", ToolCalls: toolCalls[i:end]}
+			if i == 0 && text != "" {
+				m.Content = text
+			}
+			out = append(out, m)
+		}
+		return out, nil
 
 	case "user":
 		var out []openai.ChatMessage

--- a/internal/backend/openaibe/translate_test.go
+++ b/internal/backend/openaibe/translate_test.go
@@ -2,6 +2,7 @@ package openaibe
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -284,5 +285,48 @@ func TestResponseTranslationSanitizesToolCallID(t *testing.T) {
 	}
 	if out.Content[0].ID != "Bash_0" {
 		t.Errorf("tool_use.id = %q, want sanitized id without colon", out.Content[0].ID)
+	}
+}
+
+// OpenAI rejects messages[].tool_calls arrays longer than 128 ("array too
+// long"). Claude Code can still emit a single assistant turn with more
+// tool_use blocks than that; translateMessage must split it across several
+// assistant messages rather than send one oversized array.
+func TestAssistantMessageWithManyToolCallsIsSplit(t *testing.T) {
+	const n = 152
+	blocks := []anthropic.ContentBlock{{Type: "text", Text: "working"}}
+	for i := 0; i < n; i++ {
+		blocks = append(blocks, anthropic.ContentBlock{
+			Type: "tool_use", ID: fmt.Sprintf("toolu_%d", i), Name: "read_file",
+			Input: json.RawMessage(`{"path":"a.go"}`),
+		})
+	}
+	msgs, err := translateMessage(anthropic.Message{Role: "assistant", Content: blocks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("split messages = %d, want 2", len(msgs))
+	}
+	if len(msgs[0].ToolCalls) != maxToolCallsPerMessage {
+		t.Errorf("first chunk tool_calls = %d, want %d", len(msgs[0].ToolCalls), maxToolCallsPerMessage)
+	}
+	if len(msgs[1].ToolCalls) != n-maxToolCallsPerMessage {
+		t.Errorf("second chunk tool_calls = %d, want %d", len(msgs[1].ToolCalls), n-maxToolCallsPerMessage)
+	}
+	for _, m := range msgs {
+		if m.Role != "assistant" {
+			t.Errorf("chunk role = %q, want assistant", m.Role)
+		}
+	}
+	if msgs[0].Content != "working" {
+		t.Errorf("text should land on first chunk, got %v / %v", msgs[0].Content, msgs[1].Content)
+	}
+	if msgs[1].Content != nil {
+		t.Errorf("second chunk should carry no text, got %v", msgs[1].Content)
+	}
+	// order and ids preserved across the split
+	if msgs[0].ToolCalls[0].ID != "toolu_0" || msgs[1].ToolCalls[len(msgs[1].ToolCalls)-1].ID != fmt.Sprintf("toolu_%d", n-1) {
+		t.Errorf("tool_call ids out of order across split: %+v / %+v", msgs[0].ToolCalls[0], msgs[1].ToolCalls[len(msgs[1].ToolCalls)-1])
 	}
 }


### PR DESCRIPTION
## Problem

Using gpt-5.6-sol via the auto router hit a 400 from the upstream API:

```
Invalid 'messages[2].tool_calls': array too long. Expected an array with
maximum length 128, but got an array with length 152 instead.
```

## Root cause

`internal/backend/openaibe/request.go`'s `translateMessage` fans one
Anthropic assistant message out to a single OpenAI `ChatMessage`, putting
every `tool_use` block into that message's `tool_calls` array. A single
Anthropic turn can carry more `tool_use` blocks than OpenAI's hard cap of
128 on `messages[].tool_calls` (observed here — likely after context
compaction folds a batch of prior tool calls into one turn), so the
translated request was rejected outright.

## Fix

Chunk `tool_calls` into groups of at most `maxToolCallsPerMessage = 128`,
emitting multiple consecutive assistant messages when a turn exceeds the
cap (leading text stays attached to the first chunk). Ordering is
unaffected: `TranslateRequest` just appends whatever `translateMessage`
returns, so the tool-result messages for all of them still land right
after the split chunks.

## Testing

- New regression test `TestAssistantMessageWithManyToolCallsIsSplit`
  (152 tool_use blocks → chunks of 128 + 24, ids/order preserved).
- `go build ./... && go vet ./... && go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)