### PR TITLE
eval: stop scoring infra faults as model losses, and give each model its own session id

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ Docker candidates reach the normal loopback-only router through a temporary rela
 
 Use `--task id` to select instances, `--seed` to reproduce launch order and judge blinding, `--resume` to skip completed pairs, and `--json` for machine-readable output. Infrastructure failures are unscored and never sent to the judge; `--resume` retries those pairs. `--judge none` decides only from verifier pass/fail, with equal outcomes recorded as ties.
 
+A local verifier reports its verdict through its exit code: `0` passed, `2` "I could not judge this candidate" — a missing toolchain, an image that is not present, a container that would not start — and any other non-zero means the candidate's work is wrong. Exit `2` is recorded as `verifier_error`, an infrastructure status, so the pair is unscored, hidden from the judge, and retried by `--resume`. Without that distinction a machine missing a Docker image scores as a model loss, which is worse than no measurement at all.
+
 Artifacts include raw Claude output, patches, container logs, official SWE-bench reports, FAIL_TO_PASS/PASS_TO_PASS details, blinded judge mappings, per-candidate usage and route traces, pair results, the resolved dataset metadata/fingerprint, and `summary.json`. Local setup and verifier commands execute on the host, so review third-party local manifests before running them.
 
 ## Budgets

--- a/internal/eval/docker.go
+++ b/internal/eval/docker.go
@@ -463,7 +463,7 @@ func swebenchFingerprint(manifest *Manifest, instances []SWEBenchInstance, docke
 // Infrastructure failures are returned as CandidateResult statuses (not Go
 // errors) so the paired run can checkpoint and suppress its judge cleanly.
 func (r *Runner) runSWEBenchCandidate(ctx context.Context, manifest *Manifest, task Task, attempt int, label, model, dir string) (CandidateResult, error) {
-	res := CandidateResult{Label: label, Model: model, SessionID: sessionID(r.Options.Seed, task.ID, attempt, label), ExitCode: -1}
+	res := CandidateResult{Label: label, Model: model, SessionID: sessionID(r.Options.Seed, task.ID, attempt, label, model), ExitCode: -1}
 	if err := os.RemoveAll(dir); err != nil {
 		return res, err
 	}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -599,7 +599,7 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 	if manifest.IsDataset() {
 		return r.runSWEBenchCandidate(ctx, manifest, task, attempt, label, model, dir)
 	}
-	res := CandidateResult{Label: label, Model: model, SessionID: sessionID(r.Options.Seed, task.ID, attempt, label), ExitCode: -1}
+	res := CandidateResult{Label: label, Model: model, SessionID: sessionID(r.Options.Seed, task.ID, attempt, label, model), ExitCode: -1}
 	workspace := filepath.Join(dir, "workspace")
 	if err := os.RemoveAll(dir); err != nil {
 		return res, err
@@ -738,7 +738,7 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 	}
 	prompt := judgePrompt(task, first, second)
 	argv := []string{r.Options.ClaudeBin, "--print", "--output-format", "json", "--permission-mode", "bypassPermissions", "--disallowedTools", "Task", "--model", r.Options.Judge, prompt}
-	sid := sessionID(r.Options.Seed, task.ID, attempt, "judge")
+	sid := sessionID(r.Options.Seed, task.ID, attempt, "judge", r.Options.Judge)
 	var stdout, stderr bytes.Buffer
 	judgeDir := filepath.Join(pairDir, "judge")
 	// Run from a clean directory: pairDir contains baseline/mut artifacts
@@ -978,8 +978,14 @@ func hash64(s string) uint64 {
 	}
 	return n
 }
-func sessionID(seed uint64, task string, attempt int, label string) string {
-	sum := sha256.Sum256([]byte(fmt.Sprintf("%d/%s/%d/%s", seed, task, attempt, label)))
+
+// sessionID derives the synthetic session a candidate's router usage is
+// recorded under. The model is part of it: without it, two runs comparing
+// different models at the same seed produce identical ids, and the usage
+// table — which aggregates by session id — silently merges their spend into
+// one figure that looks like a per-model result.
+func sessionID(seed uint64, task string, attempt int, label, model string) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d/%s/%d/%s/%s", seed, task, attempt, label, model)))
 	return "eval-" + hex.EncodeToString(sum[:8])
 }
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -44,7 +44,18 @@ const (
 	// interpreter, package/API mismatch, or grader) failing to produce a
 	// report for a candidate's patch.
 	StatusGradingError = "grading_error"
+	// StatusVerifierError covers a local verifier reporting that it could not
+	// run — a missing toolchain or container image, say — rather than that
+	// the candidate's work is wrong. Verifiers signal this with exit code
+	// VerifierInfraExit.
+	StatusVerifierError = "verifier_error"
 )
+
+// VerifierInfraExit is the exit code a local verifier uses to say "I could
+// not judge this candidate". Anything else non-zero is a candidate failure.
+// Without this, a machine missing a Docker image silently scores as a model
+// loss, which is worse than no measurement at all.
+const VerifierInfraExit = 2
 
 // Pair outcomes.
 const (
@@ -294,7 +305,8 @@ func (c CandidateResult) ModelFailed() bool {
 // unscoreable rather than a model loss.
 func (c CandidateResult) InfraFailed() bool {
 	switch c.Status {
-	case StatusWorkspaceError, StatusSetupError, StatusDockerError, StatusGradingError:
+	case StatusWorkspaceError, StatusSetupError, StatusDockerError, StatusGradingError,
+		StatusVerifierError:
 		return true
 	default:
 		return false
@@ -636,6 +648,14 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 		res.Verifier = VerifierResult{ExitCode: -1, Skipped: "candidate " + res.Status}
 	} else {
 		res.Verifier = verify(ctx, r.Exec, workspace, task.Verifier, filepath.Join(dir, "verifier.log"))
+		if !res.Verifier.Passed && res.Verifier.ExitCode == VerifierInfraExit {
+			// The verifier could not judge this candidate. Recording it as a
+			// loss would blame the model for our missing toolchain.
+			res.Status = StatusVerifierError
+			if res.Error == "" {
+				res.Error = "verifier could not run: " + firstLine(res.Verifier.Output)
+			}
+		}
 	}
 
 	res.Usage, res.RouteTrace = r.telemetry(res.SessionID)
@@ -643,6 +663,20 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 		return res, err
 	}
 	return res, nil
+}
+
+// firstLine is the most useful part of a verifier's output for an error
+// summary: its last line is the verdict, but the first explains the fault.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			if len(trimmed) > 300 {
+				return trimmed[:300]
+			}
+			return trimmed
+		}
+	}
+	return ""
 }
 
 // telemetry reads back the router's own record of the candidate's session.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -272,6 +272,26 @@ func TestCandidateFailureSkipsVerifier(t *testing.T) {
 // A verifier that exits with VerifierInfraExit is saying it could not judge
 // the candidate — a missing image or toolchain. Scoring that as a model loss
 // blames the model for our machine.
+// Two runs comparing different models at the same seed must not share a
+// session id: the usage table aggregates by it, so a collision merges their
+// spend into one figure that reads as a per-model result.
+func TestSessionIDSeparatesModels(t *testing.T) {
+	a := sessionID(1, "task-a", 1, "mut", "grok")
+	b := sessionID(1, "task-a", 1, "mut", "glm53")
+	if a == b {
+		t.Fatalf("different models share session id %q", a)
+	}
+	if same := sessionID(1, "task-a", 1, "mut", "grok"); same != a {
+		t.Errorf("session id is not stable: %q then %q", a, same)
+	}
+	if other := sessionID(1, "task-a", 1, "baseline", "grok"); other == a {
+		t.Error("baseline and mut arms of the same model share a session id")
+	}
+	if other := sessionID(2, "task-a", 1, "mut", "grok"); other == a {
+		t.Error("the seed no longer affects the session id")
+	}
+}
+
 func TestVerifierInfraExitIsNotAModelLoss(t *testing.T) {
 	repo := gitRepo(t)
 	ex := &scriptExecutor{
@@ -459,7 +479,7 @@ func TestTelemetryPopulatesUsageAndRoutes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sid := sessionID(7, "task-a", 1, "baseline")
+	sid := sessionID(7, "task-a", 1, "baseline", "opus")
 	now := time.Now().Truncate(time.Second)
 	if err := st.RecordUsage(store.UsageEvent{TS: now, SessionID: sid, InputTokens: 100, OutputTokens: 20, CostUSD: 0.25, DurationMS: 900, Status: 200}); err != nil {
 		t.Fatal(err)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -268,6 +269,55 @@ func TestCandidateFailureSkipsVerifier(t *testing.T) {
 	}
 }
 
+// A verifier that exits with VerifierInfraExit is saying it could not judge
+// the candidate — a missing image or toolchain. Scoring that as a model loss
+// blames the model for our machine.
+func TestVerifierInfraExitIsNotAModelLoss(t *testing.T) {
+	repo := gitRepo(t)
+	ex := &scriptExecutor{
+		claudeStdout: `{"result":"done"}`,
+		verifierErr:  exitCodeError(t, VerifierInfraExit),
+	}
+	runner := &Runner{Exec: ex, Options: Options{
+		Baseline: "a", MUT: "b", Judge: "none", OutputDir: t.TempDir(),
+		Timeout: time.Minute, ClaudeBin: "claude",
+	}}
+	s, err := runner.Run(context.Background(), testManifest(repo, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []CandidateResult{s.Pairs[0].Baseline, s.Pairs[0].MUT} {
+		if c.Status != StatusVerifierError {
+			t.Errorf("status = %q, want %q", c.Status, StatusVerifierError)
+		}
+		if !c.InfraFailed() || c.ModelFailed() {
+			t.Errorf("candidate = %+v, want infra failure and not a model failure", c)
+		}
+	}
+	if s.Pairs[0].Winner != WinnerInfraError {
+		t.Errorf("winner = %q, want %q", s.Pairs[0].Winner, WinnerInfraError)
+	}
+}
+
+// An ordinary non-zero verifier exit stays a candidate loss.
+func TestVerifierFailureIsStillAModelLoss(t *testing.T) {
+	repo := gitRepo(t)
+	ex := &scriptExecutor{claudeStdout: `{"result":"done"}`, verifierErr: exitCodeError(t, 1)}
+	runner := &Runner{Exec: ex, Options: Options{
+		Baseline: "a", MUT: "b", Judge: "none", OutputDir: t.TempDir(),
+		Timeout: time.Minute, ClaudeBin: "claude",
+	}}
+	s, err := runner.Run(context.Background(), testManifest(repo, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []CandidateResult{s.Pairs[0].Baseline, s.Pairs[0].MUT} {
+		if c.Status != StatusComplete || c.InfraFailed() || c.Verifier.Passed {
+			t.Errorf("candidate = %+v, want a completed run with a failed verifier", c)
+		}
+	}
+}
+
 func TestInfraFailureSuppressesJudgeAndIsNotTie(t *testing.T) {
 	repo := gitRepo(t)
 	ex := &scriptExecutor{
@@ -484,6 +534,15 @@ func TestCandidateArtifactIsDurable(t *testing.T) {
 	if result.Status != StatusComplete || !result.Verifier.Ran || !result.Verifier.Passed {
 		t.Errorf("result = %+v", result)
 	}
+}
+
+func exitCodeError(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	if err == nil {
+		t.Fatalf("expected exit %d", code)
+	}
+	return err
 }
 
 func exitError(t *testing.T) error {


### PR DESCRIPTION
Two defects in `agentic eval` that both corrupt results while looking like results. Found while running a four-model sweep.

## Verifier exit 2 is now an infra failure

A local verifier had one bit to report with: pass or fail. A missing Docker image, a container that would not start, or a crashed check therefore scored as a loss for whichever model happened to draw it.

Verifiers can now exit `2` to mean "I could not judge this candidate". That maps to a new `verifier_error` status which `InfraFailed` reports, so the pair is recorded as an infra error, suppressed from the judge, and re-run by `--resume`. Any other non-zero exit still means the candidate's work is wrong.

This fired on a real run during the sweep: a Postgres container hit an `initdb` restart race, all eight checks reported infra, and the candidate was held out instead of taking a silent 0/8 against the baseline.

## Each model gets its own session id

`sessionID` hashed `seed/task/attempt/label` and omitted the model, so two runs comparing different models at the same seed produced identical ids. The router's usage table aggregates by session id, so their spend merged.

The sweep made it obvious: grok and glm53-flash both reported exactly `$0.2204` for the same candidate, and gpt-5.6-sol and glm53 both exactly `$0.5219` — identical to four decimal places across different models.

Cost was the only contaminated axis; pass/fail and latency are measured directly by the verifier and the runner. But a per-model spend figure that is actually four runs added together is the worst kind of wrong, because nothing about it looks broken.

## Compatibility

Session ids change. A `--resume` against a run directory created by an older build will not match the ids recorded in its `candidate.json` files; completed pairs are still skipped by task and attempt, so resuming works, and only the historical id linkage differs.

## Tests

- `TestVerifierInfraExitIsNotAModelLoss` — exit 2 yields `verifier_error`, `InfraFailed()` true, `ModelFailed()` false, pair winner `infra_error`
- `TestVerifierFailureIsStillAModelLoss` — exit 1 remains an ordinary candidate loss
- `TestSessionIDSeparatesModels` — different models differ, same inputs stay stable, arm and seed still matter

Full suite green: 14 packages, 0 failures. README documents the verifier exit-code contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)