### PR TITLE
Cap the router log instead of growing it forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ A local verifier reports its verdict through its exit code: `0` passed, `2` "I c
 
 Artifacts include raw Claude output, patches, container logs, official SWE-bench reports, FAIL_TO_PASS/PASS_TO_PASS details, blinded judge mappings, per-candidate usage and route traces, pair results, the resolved dataset metadata/fingerprint, and `summary.json`. Local setup and verifier commands execute on the host, so review third-party local manifests before running them.
 
+The router writes `~/.agentic/router.log`. It is capped at 8 MiB and keeps three older generations (`router.log.1` … `.3`), so the log costs at most 32 MiB on disk. An oversized log left by an earlier version is rotated on the next write rather than truncated.
+
+
 ## Budgets
 
 Daily, weekly, and monthly caps — global and per profile. When a cap is hit, the router refuses the *next* request with a clear message that shows up right in the Claude Code TUI; in-flight responses are never cut. Warnings surface in the statusline (`agentic setup` registers it), which shows live session and daily spend:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/maorbril/agentic/internal/config"
 	"github.com/maorbril/agentic/internal/launch"
+	"github.com/maorbril/agentic/internal/logrotate"
 	"github.com/maorbril/agentic/internal/router"
 )
 
@@ -86,12 +87,20 @@ func loadConfig() (*config.Config, string, error) {
 	return cfg, dataDir, nil
 }
 
+// Router log ceiling: the current file plus logMaxGenerations archives, so
+// the log costs at most logMaxBytes*(1+logMaxGenerations) on disk. It used to
+// have no ceiling at all and grew past the usage database beside it.
+const (
+	logMaxBytes       = 8 << 20 // 8 MiB
+	logMaxGenerations = 3
+)
+
 func logger() *slog.Logger {
 	dataDir, err := config.DataDir()
 	if err == nil {
-		if f, err := os.OpenFile(filepath.Join(dataDir, "router.log"),
-			os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600); err == nil {
-			return slog.New(slog.NewTextHandler(f, nil))
+		if w, err := logrotate.Open(filepath.Join(dataDir, "router.log"),
+			logMaxBytes, logMaxGenerations); err == nil {
+			return slog.New(slog.NewTextHandler(w, nil))
 		}
 	}
 	return slog.New(slog.NewTextHandler(os.Stderr, nil))

--- a/internal/logrotate/logrotate.go
+++ b/internal/logrotate/logrotate.go
@@ -1,0 +1,123 @@
+// Package logrotate provides a size-bounded log file.
+//
+// The router log had no ceiling: it was opened append-only and grew for as
+// long as the install lived, reaching tens of megabytes and outgrowing the
+// usage database it sat next to. A log nobody prunes is a slow disk leak, and
+// the oldest lines are the least useful ones to keep.
+package logrotate
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+// Writer appends to a file and rotates it once it would exceed MaxBytes,
+// keeping at most Keep older generations alongside it (path.1 … path.N).
+// It is safe for concurrent use: slog handlers write from any goroutine.
+type Writer struct {
+	path     string
+	maxBytes int64
+	keep     int
+
+	mu   sync.Mutex
+	file *os.File
+	size int64
+}
+
+// Open opens path for appending, rotating when a write would take it past
+// maxBytes. keep is the number of older generations to retain; 0 keeps none,
+// so the log simply restarts. An existing file that is already oversized
+// rotates on its first write rather than being truncated, so nothing that has
+// been written is thrown away silently.
+func Open(path string, maxBytes int64, keep int) (*Writer, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("logrotate: maxBytes must be positive, got %d", maxBytes)
+	}
+	if keep < 0 {
+		return nil, fmt.Errorf("logrotate: keep must not be negative, got %d", keep)
+	}
+	w := &Writer{path: path, maxBytes: maxBytes, keep: keep}
+	if err := w.open(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *Writer) open() error {
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	size := int64(0)
+	if fi, err := f.Stat(); err == nil {
+		size = fi.Size()
+	}
+	w.file, w.size = f, size
+	return nil
+}
+
+func (w *Writer) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return 0, os.ErrClosed
+	}
+	// Rotate before the write that would cross the line, so a single record
+	// is never split across two generations. A record larger than the whole
+	// budget still goes through in one piece — truncating a log line is worse
+	// than briefly exceeding the ceiling.
+	if w.size > 0 && w.size+int64(len(p)) > w.maxBytes {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := w.file.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotate closes the current file, shifts the generations along, and opens a
+// fresh one. Another process holding the old descriptor keeps writing to the
+// renamed file, which is the usual POSIX behaviour and harmless here: it
+// stops when that process does.
+func (w *Writer) rotate() error {
+	if err := w.file.Close(); err != nil {
+		return err
+	}
+	w.file = nil
+	if w.keep == 0 {
+		if err := os.Remove(w.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return w.open()
+	}
+	// Drop the oldest, then walk the rest down one slot.
+	oldest := fmt.Sprintf("%s.%d", w.path, w.keep)
+	if err := os.Remove(oldest); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for i := w.keep - 1; i >= 1; i-- {
+		from := fmt.Sprintf("%s.%d", w.path, i)
+		to := fmt.Sprintf("%s.%d", w.path, i+1)
+		if err := os.Rename(from, to); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := os.Rename(w.path, w.path+".1"); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return w.open()
+}
+
+// Close releases the underlying file.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}

--- a/internal/logrotate/logrotate_test.go
+++ b/internal/logrotate/logrotate_test.go
@@ -1,0 +1,156 @@
+package logrotate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func lines(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestRotatesAtTheCeiling(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "router.log")
+	w, err := Open(path, 32, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 10; i++ {
+		if _, err := fmt.Fprintf(w, "record-%02d\n", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 10 records of 10 bytes against a 32-byte ceiling: the current file
+	// holds the newest few, older ones live in the generations.
+	if got := len(lines(t, path)); got > 32 {
+		t.Errorf("current log is %d bytes, want <= 32", got)
+	}
+	if !strings.Contains(lines(t, path), "record-09") {
+		t.Error("newest record is not in the current log")
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Errorf("expected a rotated generation: %v", err)
+	}
+}
+
+func TestKeepsOnlyNGenerations(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "router.log")
+	w, err := Open(path, 16, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 40; i++ {
+		if _, err := fmt.Fprintf(w, "line-%03d\n", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	// router.log plus at most two generations, however many rotations ran.
+	if len(names) != 3 {
+		t.Errorf("found %v, want router.log plus exactly 2 generations", names)
+	}
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Error("a third generation survived the keep limit")
+	}
+}
+
+func TestOversizedExistingLogRotatesRatherThanTruncating(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "router.log")
+	// stand in for the 26MB log an older build left behind
+	if err := os.WriteFile(path, []byte(strings.Repeat("old\n", 50)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w, err := Open(path, 32, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	if _, err := fmt.Fprintln(w, "new"); err != nil {
+		t.Fatal(err)
+	}
+	if got := lines(t, path); strings.Contains(got, "old") {
+		t.Error("the oversized log was appended to instead of rotated")
+	}
+	if got := lines(t, path+".1"); !strings.Contains(got, "old") {
+		t.Error("the previous contents were discarded rather than kept as a generation")
+	}
+}
+
+func TestKeepZeroRestartsTheLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "router.log")
+	w, err := Open(path, 16, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 10; i++ {
+		if _, err := fmt.Fprintf(w, "line-%03d\n", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := os.Stat(path + ".1"); !os.IsNotExist(err) {
+		t.Error("keep 0 should leave no generations behind")
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("found %d files, want just the log", len(entries))
+	}
+}
+
+func TestConcurrentWritersDoNotRace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "router.log")
+	w, err := Open(path, 64, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				if _, err := fmt.Fprintf(w, "g%d-i%02d\n", g, i); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func TestRejectsNonsenseLimits(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Open(filepath.Join(dir, "a.log"), 0, 1); err == nil {
+		t.Error("maxBytes 0 should be rejected")
+	}
+	if _, err := Open(filepath.Join(dir, "b.log"), 16, -1); err == nil {
+		t.Error("negative keep should be rejected")
+	}
+}


### PR DESCRIPTION
`router.log` was opened append-only with no ceiling, so it grew for as long as the install lived. On my machine it reached **26 MB** — larger than the usage database beside it — and nothing in the codebase would ever have pruned it.

## What changed

`internal/logrotate` is a small size-bounded writer:

- rotates **before** the write that would cross the limit, so a single log record is never split across two generations
- keeps `N` older generations (`router.log.1` … `.N`) and drops the oldest
- safe for concurrent use — slog handlers write from any goroutine
- a record larger than the whole budget still goes through in one piece; truncating a log line is worse than briefly exceeding the ceiling

The router log is capped at **8 MiB with 3 generations**, so it costs at most 32 MiB on disk.

## Upgrading from an oversized log

An existing log that is already past the limit is **rotated on its first write, not truncated** — nothing already written is discarded. Verified with a real build against a 10.8 MB log: it became `router.log.1` and a fresh `router.log` started at 432 bytes.

One deliberate note in the code: if an older process still holds the pre-rotation descriptor it keeps writing to the renamed file. That is ordinary POSIX behaviour and harmless here — it stops when that process does.

## Tests

Six, all passing under `-race`:

- rotates at the ceiling, newest record in the current file
- never exceeds the keep limit however many rotations run
- an oversized existing log is rotated, not truncated, and its contents survive as a generation
- `keep: 0` restarts the log and leaves no generations
- eight concurrent writers, no race
- nonsense limits rejected

Full suite green. README documents the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)