### PR TITLE
Rename agentic to gremlord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,14 @@ jobs:
           EXT=""
           [ "$GOOS" = "windows" ] && EXT=".exe"
           go build -trimpath \
-            -ldflags "-s -w -X github.com/maorbril/agentic/internal/router.Version=$TAG" \
-            -o "agentic-$GOOS-$GOARCH$EXT" .
+            -ldflags "-s -w -X github.com/gremlord/gremlord/internal/router.Version=$TAG" \
+            -o "gremlord-$GOOS-$GOARCH$EXT" .
       - name: Upload asset
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
-          gh release upload "$TAG" agentic-${{ matrix.goos }}-${{ matrix.goarch }}* --clobber
+          gh release upload "$TAG" gremlord-${{ matrix.goos }}-${{ matrix.goarch }}* --clobber
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,25 @@ jobs:
           TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
           gh release upload "$TAG" gremlord-${{ matrix.goos }}-${{ matrix.goarch }}* --clobber
 
+      # A pre-rename agentic binary asks for agentic-$os-$arch. Publishing the
+      # same bytes under the old name is what lets `agentic update` succeed and
+      # pull the renamed build, which then migrates ~/.agentic on its next run.
+      # Without it every existing install is stranded on a 404.
+      #
+      # Remove this step in the release after the rename.
+      - name: Upload pre-rename compatibility asset
+        if: ${{ vars.SKIP_LEGACY_ASSETS != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.event.release.tag_name || github.event.inputs.tag }}"
+          EXT=""
+          [ "${{ matrix.goos }}" = "windows" ] && EXT=".exe"
+          SRC="gremlord-${{ matrix.goos }}-${{ matrix.goarch }}$EXT"
+          LEGACY="agentic-${{ matrix.goos }}-${{ matrix.goarch }}$EXT"
+          cp "$SRC" "$LEGACY"
+          gh release upload "$TAG" "$LEGACY" --clobber
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
+/gremlord
 /agentic
 *.log
 .env
 .env.*
-.agentic/evals/
+.gremlord/evals/
 .DS_Store
 .claude/
 logs/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-BINARY := agentic
+BINARY := gremlord
 VERSION ?= dev
-LDFLAGS := -ldflags "-X github.com/maorbril/agentic/internal/router.Version=$(VERSION)"
+LDFLAGS := -ldflags "-X github.com/gremlord/gremlord/internal/router.Version=$(VERSION)"
 
 .PHONY: build test vet install clean
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,53 @@
-# agentic
+# gremlord
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![GitHub stars](https://img.shields.io/github/stars/MaorBril/agentic)](https://github.com/MaorBril/agentic/stargazers)
-[![Last commit](https://img.shields.io/github/last-commit/MaorBril/agentic)](https://github.com/MaorBril/agentic/commits/main)
-[![Go](https://img.shields.io/github/go-mod/go-version/MaorBril/agentic)](go.mod)
+[![GitHub stars](https://img.shields.io/github/stars/gremlord/gremlord)](https://github.com/gremlord/gremlord/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/gremlord/gremlord)](https://github.com/gremlord/gremlord/commits/main)
+[![Go](https://img.shields.io/github/go-mod/go-version/gremlord/gremlord)](go.mod)
 
-**Run Claude Code on any model, with a budget.** Docs and demos: [runagentic.dev](https://runagentic.dev)
+**Run Claude Code on any model, with a budget.** Docs and demos: [gremlord.com](https://gremlord.com)
 
-![agentic demo](assets/hero.gif)
+Formerly agentic — same tool, new name. Your existing config and cost history are
+carried over from `~/.agentic` the first time you run it.
 
-agentic wraps Claude Code in a thin local router. Your sessions look and feel exactly like `claude` — same TUI, same tools, same updates — but the model behind them can be Anthropic, OpenAI, xAI, or anything OpenAI-compatible (Ollama, vLLM, OpenRouter, DeepSeek, Groq). Whole tasks can also be delegated to a locally logged-in Codex or Grok CLI under your own subscription. Every routed API token is metered, priced, and checked against budgets you set.
+![gremlord demo](assets/hero.gif)
+
+<!-- TODO: hero.gif still shows the old `agentic` command name and the old
+     statusline. Re-record with `assets/hero.tape` (the tape itself is updated). -->
+
+gremlord wraps Claude Code in a thin local router. Your sessions look and feel exactly like `claude` — same TUI, same tools, same updates — but the model behind them can be Anthropic, OpenAI, xAI, or anything OpenAI-compatible (Ollama, vLLM, OpenRouter, DeepSeek, Groq). Whole tasks can also be delegated to a locally logged-in Codex or Grok CLI under your own subscription. Every routed API token is metered, priced, and checked against budgets you set.
 
 ```bash
-agentic                  # Claude Code, tracked, on your default profile
-agentic -p cheap         # same session, cheaper models
-agentic --model grok     # one-off model override
-agentic cost             # where did today's $4.31 go?
+gremlord                  # Claude Code, tracked, on your default profile
+gremlord -p cheap         # same session, cheaper models
+gremlord --model grok     # one-off model override
+gremlord cost             # where did today's $4.31 go?
 ```
 
 ## Why
 
 Claude Code is a great harness, and it keeps getting better — forking it means losing that. But it only talks to one provider, and it doesn't answer two questions you eventually ask: *how much did that session cost?* and *can I run the cheap parts on a cheap model?*
 
-agentic answers both without touching Claude Code itself. Claude Code officially supports pointing at a gateway via `ANTHROPIC_BASE_URL`; agentic is that gateway, plus the CLI around it.
+gremlord answers both without touching Claude Code itself. Claude Code officially supports pointing at a gateway via `ANTHROPIC_BASE_URL`; gremlord is that gateway, plus the CLI around it.
 
 ## Compared to other options
 
 There are three ways people solve "I want Claude Code but not locked to one provider":
 
-| | agentic | claude-code-router / claude-code-proxy forks / LiteLLM | OpenCode, Crush, Goose, Aider |
+| | gremlord | claude-code-router / claude-code-proxy forks / LiteLLM | OpenCode, Crush, Goose, Aider |
 |---|---|---|---|
 | **Harness** | Real Claude Code, unmodified, auto-updating | Real Claude Code, unmodified | Different harness entirely — own prompts, tools, TUI |
 | **Runs as** | Static Go binary, no daemon (leader election over a fixed port) | Daemon / server process you deploy and administer | Standalone CLI you run instead of Claude Code |
-| **Cost & budgets** | First-class CLI: `agentic cost`, live statusline, hard-stop daily/weekly/monthly budgets | Usually a dashboard (LiteLLM) or not built in | Varies by tool, rarely budget-gated |
+| **Cost & budgets** | First-class CLI: `gremlord cost`, live statusline, hard-stop daily/weekly/monthly budgets | Usually a dashboard (LiteLLM) or not built in | Varies by tool, rarely budget-gated |
 | **Model routing** | Aliases + a built-in LLM-classifier tier router (`auto`), sticky per turn | Rule-based routing configs; no classifier-based tiering | Manual model switch, no auto-routing |
 | **Memory** | Composes with [clauder](https://github.com/MaorBril/clauder) — separate binary, optional | Not their concern | Varies |
 
-The short version: agentic doesn't try to be a better harness than Claude Code — it keeps Claude Code exactly as Anthropic ships it and only swaps what's behind `ANTHROPIC_BASE_URL`. If you want a different agent loop altogether, OpenCode/Crush/Goose/Aider are the right layer to look at instead. If you want a gateway you deploy and administer for a team, LiteLLM is a more mature choice for that. agentic is for a single developer who wants `claude`, unmodified, with a budget and a cheap-model escape hatch, installed in one command and running with nothing to operate.
+The short version: gremlord doesn't try to be a better harness than Claude Code — it keeps Claude Code exactly as Anthropic ships it and only swaps what's behind `ANTHROPIC_BASE_URL`. If you want a different agent loop altogether, OpenCode/Crush/Goose/Aider are the right layer to look at instead. If you want a gateway you deploy and administer for a team, LiteLLM is a more mature choice for that. gremlord is for a single developer who wants `claude`, unmodified, with a budget and a cheap-model escape hatch, installed in one command and running with nothing to operate.
 
 ## How it works
 
 ```
-agentic (launcher) ──▶ claude (unmodified, auto-updating)
+gremlord (launcher) ──▶ claude (unmodified, auto-updating)
                           │  ANTHROPIC_BASE_URL
                           ▼
                    local router (127.0.0.1)
@@ -54,37 +60,37 @@ agentic (launcher) ──▶ claude (unmodified, auto-updating)
         Anthropic · OpenAI · xAI · Ollama · vLLM · OpenRouter · Codex CLI · Grok CLI · ...
 ```
 
-There is no daemon. The first `agentic` session binds the router port and serves everyone; when it exits, another running session takes over within a couple of seconds. The last session out turns off the lights.
+There is no daemon. The first `gremlord` session binds the router port and serves everyone; when it exits, another running session takes over within a couple of seconds. The last session out turns off the lights.
 
 Model names are aliases you define. Claude Code treats model IDs as opaque strings, so `ANTHROPIC_MODEL=grok` flows straight through and the router resolves it. Anything starting with `claude-` passes through to Anthropic untouched — background tasks keep working even when your main model is something else entirely.
 
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/maorbril/agentic/main/install.sh | sh
-agentic setup
+curl -fsSL https://raw.githubusercontent.com/gremlord/gremlord/main/install.sh | sh
+gremlord setup
 ```
 
-Sixty seconds later: the same `claude` you know, now with `agentic cost` telling you what today cost and a budget that stops the spend when you say so.
+Sixty seconds later: the same `claude` you know, now with `gremlord cost` telling you what today cost and a budget that stops the spend when you say so.
 
-Or from source: `go install github.com/maorbril/agentic@latest`
+Or from source: `go install github.com/gremlord/gremlord@latest`
 
-To update later, run `agentic update` (or `agentic update --check` to see if one's available without installing it). This updates agentic itself; Claude Code keeps auto-updating on its own regardless.
+To update later, run `gremlord update` (or `gremlord update --check` to see if one's available without installing it). This updates gremlord itself; Claude Code keeps auto-updating on its own regardless.
 
 ## Configure
 
-Everything lives in `~/.agentic/config.yaml`, and everything is editable from the terminal:
+Everything lives in `~/.gremlord/config.yaml`, and everything is editable from the terminal:
 
 ```bash
-agentic providers add openai --type openai --base-url https://api.openai.com/v1 \
+gremlord providers add openai --type openai --base-url https://api.openai.com/v1 \
     --key-env OPENAI_API_KEY --max-tokens-param max_completion_tokens
-agentic models add gpt --provider openai --id gpt-5.2 --reasoning effort --max-output 16384
-agentic models test gpt          # 1-token probe: did I configure it right?
+gremlord models add gpt --provider openai --id gpt-5.2 --reasoning effort --max-output 16384
+gremlord models test gpt          # 1-token probe: did I configure it right?
 
-agentic providers add codex --type cli --dialect codex --sandbox workspace-write
-agentic models add codex --provider codex   # subscription login; no API key
+gremlord providers add codex --type cli --dialect codex --sandbox workspace-write
+gremlord models add codex --provider codex   # subscription login; no API key
 
-agentic budget set --daily 25
+gremlord budget set --daily 25
 ```
 
 Edits apply to live sessions immediately — the CLI hot-reloads the running router.
@@ -106,7 +112,7 @@ Aliases backed by a `cli` provider are subagent-only: they cannot be a profile m
 Instead of picking models by hand, let a cheap LLM triage every task:
 
 ```bash
-agentic routing set auto --classifier haiku \
+gremlord routing set auto --classifier haiku \
     --deep opus --standard sonnet --light qwen
 ```
 
@@ -138,36 +144,36 @@ routing:
 Configure the same policy from the CLI with repeatable task flags; later `routing set` calls preserve existing task mappings unless a matching flag updates one:
 
 ```bash
-agentic routing set auto --classifier haiku \
+gremlord routing set auto --classifier haiku \
     --deep opus --standard sonnet --light qwen \
     --task implementation=grok --task sql_data=grok \
     --task debugging=grok --task code_review=grok \
     --task architecture=fable --task security_review=fable \
     --task critical_review=opus
-agentic routing list
+gremlord routing list
 ```
 
-A recognized task mapping takes precedence over the selected tier. Unrecognized or unmatched work uses the tier normally. If the mapped model cannot hold the request, the router falls back to the smallest eligible capability tier. Pinned sessions (`pin_tiers` / `X-Agentic-Pin-Model`) bypass task and tier classification entirely. A `cli` alias cannot appear as a classifier, tier, or task mapping; validation rejects it so auto-routing can never silently start an independent agent run in your repository. Task classification is a model-selection hint, not a security boundary; enforce sensitive-work policy separately.
+A recognized task mapping takes precedence over the selected tier. Unrecognized or unmatched work uses the tier normally. If the mapped model cannot hold the request, the router falls back to the smallest eligible capability tier. Pinned sessions (`pin_tiers` / `X-Gremlord-Pin-Model`) bypass task and tier classification entirely. A `cli` alias cannot appear as a classifier, tier, or task mapping; validation rejects it so auto-routing can never silently start an independent agent run in your repository. Task classification is a model-selection hint, not a security boundary; enforce sensitive-work policy separately.
 
 Every decision is logged, and task choices appear in the existing reason field:
 
 ```
-$ grep autoroute ~/.agentic/router.log
+$ grep autoroute ~/.gremlord/router.log
 ... alias=auto tier=standard model=grok reason=task:implementation
 ... alias=auto tier=deep model=fable reason=task:security_review
 ```
 
-`agentic cost --by model` then shows how spend actually distributed. Each turn uses one tiny tier-only or combined tier-and-task request to the classifier model (~$0.0005 with haiku). Because config parsing is strict, a config containing `tasks:` requires an agentic binary that supports task routing; older binaries reject the field instead of silently ignoring it.
+`gremlord cost --by model` then shows how spend actually distributed. Each turn uses one tiny tier-only or combined tier-and-task request to the classifier model (~$0.0005 with haiku). Because config parsing is strict, a config containing `tasks:` requires an gremlord binary that supports task routing; older binaries reject the field instead of silently ignoring it.
 
 ## Auto Goal
 
 Whenever a `routing:` alias like `auto` is in play, a second, independent classifier pass looks at each new user turn and asks a different question: not "which tier?" but "does this look like it needs a persistent loop rather than a single reply?" — monitoring a long build, retrying until a condition holds, babysitting a deploy, polling for external state.
 
-When the answer is yes, agentic doesn't (and can't) start a loop itself — the router only ever sees request and response bodies, it has no execution context inside the Claude Code process. Instead it appends a system-reminder to the request naming the harness's own mechanisms directly:
+When the answer is yes, gremlord doesn't (and can't) start a loop itself — the router only ever sees request and response bodies, it has no execution context inside the Claude Code process. Instead it appends a system-reminder to the request naming the harness's own mechanisms directly:
 
 ```
 <system-reminder>
-agentic: this task looks well suited to a recurring goal loop rather than a
+gremlord: this task looks well suited to a recurring goal loop rather than a
 single reply (polling a long build). If a persistent loop would help —
 checking back on progress, retrying until a condition holds, babysitting a
 long-running process — call ScheduleWakeup with prompt
@@ -177,7 +183,7 @@ pass.
 </system-reminder>
 ```
 
-Claude Code decides whether to act on it — the reminder is a nudge, not a command. Decisions are logged (`grep autogoal ~/.agentic/router.log`) and, like tier decisions, surfaced in the statusline (`⟳ goal (polling a long build)`).
+Claude Code decides whether to act on it — the reminder is a nudge, not a command. Decisions are logged (`grep autogoal ~/.gremlord/router.log`) and, like tier decisions, surfaced in the statusline (`⟳ goal (polling a long build)`).
 
 This rides on the same classifier alias as dynamic routing, so it's on wherever `routing: auto` is configured, at the cost of one extra cheap classifier call per new turn alongside the tier call.
 
@@ -186,11 +192,11 @@ This rides on the same classifier alias as dynamic routing, so it's on wherever 
 Claude Code sizes its auto-compact against the ~200K window of the Claude model it thinks it's talking to. Routed models rarely match that: a local qwen holds 32K, GPT holds 400K, and many models get unreliable well before their advertised limit. Declare what a model really holds and the router scales every token count it reports so the client's context gauge — and therefore auto-compact — tracks the *real* window:
 
 ```bash
-agentic models add qwen --provider local --id qwen3-coder-30b --context-window 32768
-agentic models add glm  --provider z --id glm-4.7 --context-window 200000 --effective-context 60000
+gremlord models add qwen --provider local --id qwen3-coder-30b --context-window 32768
+gremlord models add glm  --provider z --id glm-4.7 --context-window 200000 --effective-context 60000
 ```
 
-`effective_context` is the attention knob: the client compacts at 60K real tokens even though the window is nominally 200K, keeping the model in its coherent range. Pricing and budgets always record true usage; `agentic context` shows a session's true-vs-reported trajectory for tuning these numbers.
+`effective_context` is the attention knob: the client compacts at 60K real tokens even though the window is nominally 200K, keeping the model in its coherent range. Pricing and budgets always record true usage; `gremlord context` shows a session's true-vs-reported trajectory for tuning these numbers.
 
 Under `model: auto` the gauge is anchored to **one** budget for the whole rule — by default the largest window the rule can route to — so it means the same thing on every turn. Scaling per serving model instead made a conversation read 30% full on a 1M model and 95% on a 200K one, and since Claude Code compacts on whatever the last turn reported, a single cheap turn could throw away context the big model still had room for. Turns that outgrow a smaller tier are remapped up to one that fits, which the router already did for size. Set `context_gauge: min` on the rule to keep every tier reachable at any conversation length instead, or `context_gauge: model` for the old per-request behavior.
 
@@ -200,15 +206,15 @@ Details, the cost trade-off, and research methodology: [docs/context-scaling.md]
 
 Three more things keep a session from spending window on nothing:
 
-- **Estimator calibration.** Token counts for translated models are a character heuristic, deliberately biased high. The router measures that guess against what upstream actually billed (per model, from its own usage log) and corrects it, so an over-count stops being subtracted from every context budget it checks. `agentic context` prints the measured accuracy; a model needs 20 requests before its correction is trusted, and corrections are clamped so a bad sample can never shrink an estimate into a window it will not fit.
-- **Deferred tool loading.** Claude Code can hold back tool schemas — sending the deferred tools' names up front and a full schema only once the model pulls one in — but it switches that off whenever `ANTHROPIC_BASE_URL` is not a first-party Anthropic host, which the router never is. Sessions were paying every builtin and MCP schema on every request: measured at 186K of tool schemas inside a 200K frame on a session with 165 MCP tools, over the limit before the first turn. Sessions now ask for it back (`ENABLE_TOOL_SEARCH=true`). Deferral does need a model that calls `ToolSearch` when it sees a tool withheld, so a profile pinned to one that doesn't can set `tool_search: false`; an explicit value in your shell outranks both — `false` for the old eager behavior, `auto:N` to sample it. `agentic eval` pins it off so stored runs stay comparable wherever they were launched from.
-- **Cache-hit reporting.** `agentic cost` shows what share of each model's input was served from an upstream prefix cache. Prompt caching is the single largest lever on the input bill, and it was previously invisible — worth checking before reaching for anything cleverer.
+- **Estimator calibration.** Token counts for translated models are a character heuristic, deliberately biased high. The router measures that guess against what upstream actually billed (per model, from its own usage log) and corrects it, so an over-count stops being subtracted from every context budget it checks. `gremlord context` prints the measured accuracy; a model needs 20 requests before its correction is trusted, and corrections are clamped so a bad sample can never shrink an estimate into a window it will not fit.
+- **Deferred tool loading.** Claude Code can hold back tool schemas — sending the deferred tools' names up front and a full schema only once the model pulls one in — but it switches that off whenever `ANTHROPIC_BASE_URL` is not a first-party Anthropic host, which the router never is. Sessions were paying every builtin and MCP schema on every request: measured at 186K of tool schemas inside a 200K frame on a session with 165 MCP tools, over the limit before the first turn. Sessions now ask for it back (`ENABLE_TOOL_SEARCH=true`). Deferral does need a model that calls `ToolSearch` when it sees a tool withheld, so a profile pinned to one that doesn't can set `tool_search: false`; an explicit value in your shell outranks both — `false` for the old eager behavior, `auto:N` to sample it. `gremlord eval` pins it off so stored runs stay comparable wherever they were launched from.
+- **Cache-hit reporting.** `gremlord cost` shows what share of each model's input was served from an upstream prefix cache. Prompt caching is the single largest lever on the input bill, and it was previously invisible — worth checking before reaching for anything cleverer.
 
-`agentic context` also breaks down where a session's context goes — system prompt, tool schemas, conversation — since the first two are re-sent in full on every request whatever the turn is about.
+`gremlord context` also breaks down where a session's context goes — system prompt, tool schemas, conversation — since the first two are re-sent in full on every request whatever the turn is about.
 
 ## Model evaluations
 
-`agentic eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code in isolation, records router usage and route decisions under its own session ID, and produces a patch. An optional judge sees blinded patches and verifier evidence; it never sees model names, cost, or execution order.
+`gremlord eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code in isolation, records router usage and route decisions under its own session ID, and produces a patch. An optional judge sees blinded patches and verifier evidence; it never sees model names, cost, or execution order.
 
 There are two executor types. A local manifest supplies its repository, setup command, and verifier directly:
 
@@ -243,14 +249,14 @@ sandbox:
 The same manifest is in [`examples/swebench-smoke.yaml`](examples/swebench-smoke.yaml). SWE-bench runs require Docker and Python 3.10 or newer with the exact supported package version:
 
 ```bash
-python3 -m venv ~/.agentic/swebench-venv
-~/.agentic/swebench-venv/bin/pip install 'swebench==4.1.0'
+python3 -m venv ~/.gremlord/swebench-venv
+~/.gremlord/swebench-venv/bin/pip install 'swebench==4.1.0'
 
-agentic eval run examples/swebench-smoke.yaml \
-  --python ~/.agentic/swebench-venv/bin/python \
+gremlord eval run examples/swebench-smoke.yaml \
+  --python ~/.gremlord/swebench-venv/bin/python \
   --baseline opus --mut auto --judge sonnet \
-  --attempts 1 --timeout 45m --output ~/.agentic/evals/swebench-smoke
-agentic eval report ~/.agentic/evals/swebench-smoke
+  --attempts 1 --timeout 45m --output ~/.gremlord/evals/swebench-smoke
+gremlord eval report ~/.gremlord/evals/swebench-smoke
 ```
 
 A real one-task run comparing `kimi-k3` against `opus` produced:
@@ -275,38 +281,38 @@ A local verifier reports its verdict through its exit code: `0` passed, `2` "I c
 
 Artifacts include raw Claude output, patches, container logs, official SWE-bench reports, FAIL_TO_PASS/PASS_TO_PASS details, blinded judge mappings, per-candidate usage and route traces, pair results, the resolved dataset metadata/fingerprint, and `summary.json`. Local setup and verifier commands execute on the host, so review third-party local manifests before running them.
 
-The router writes `~/.agentic/router.log`. It is capped at 8 MiB and keeps three older generations (`router.log.1` … `.3`), so the log costs at most 32 MiB on disk. An oversized log left by an earlier version is rotated on the next write rather than truncated.
+The router writes `~/.gremlord/router.log`. It is capped at 8 MiB and keeps three older generations (`router.log.1` … `.3`), so the log costs at most 32 MiB on disk. An oversized log left by an earlier version is rotated on the next write rather than truncated.
 
 
 ## Budgets
 
-Daily, weekly, and monthly caps — global and per profile. When a cap is hit, the router refuses the *next* request with a clear message that shows up right in the Claude Code TUI; in-flight responses are never cut. Warnings surface in the statusline (`agentic setup` registers it), which shows live session and daily spend:
+Daily, weekly, and monthly caps — global and per profile. When a cap is hit, the router refuses the *next* request with a clear message that shows up right in the Claude Code TUI; in-flight responses are never cut. Warnings surface in the statusline (`gremlord setup` registers it), which shows live session and daily spend:
 
 ```
 main · sonnet · sess $0.84 · day $4.31/$25 [██░░░░]
 ```
 
-`agentic cost` breaks spend down by model, profile, or session, and `--json` gives you the raw rows.
+`gremlord cost` breaks spend down by model, profile, or session, and `--json` gives you the raw rows.
 
 ## The fine print
 
-Two things you should understand before routing through agentic:
+Two things you should understand before routing through gremlord:
 
-- **Billing.** Normal traffic through the router is billed to **API keys**, not your Claude Pro/Max subscription. OAuth credentials are never proxied. For Claude subscription billing, use a `passthrough: true` profile — normal claude, no tracking. [CLI delegation](#delegating-to-another-cli) instead bills the peer CLI's own subscription (ChatGPT or SuperGrok/X Premium+) through its cached local login, which agentic invokes but never reads. That spend happens outside the router, so delegated runs appear in `agentic cost` as $0 unpriced rows with estimated token counts and budgets cannot gate them.
-- **Fidelity.** Non-Anthropic models work through translation, but Claude Code's prompts and tool patterns are tuned for Claude, so expect them to be clunkier in the main loop. They shine as cheap workhorses for background tasks and subagents. Specific gaps: no `cache_control` breakpoints on OpenAI-dialect backends (provider-side implicit caching still shows up as cache reads, measurable with `agentic cost`), thinking blocks are display-only, Anthropic server tools (web search, code execution) are unavailable on translated models, `top_k` is dropped, stop sequences truncate to four, and token counting for translated models is a deliberate ~15% overestimate so auto-compact fires early instead of overflowing context. Set `max_output` on models whose output cap is below what Claude Code requests (it asks for 32K), and `context_window` on models whose window differs from the ~200K Claude Code assumes (see [Context scaling](#context-scaling)).
+- **Billing.** Normal traffic through the router is billed to **API keys**, not your Claude Pro/Max subscription. OAuth credentials are never proxied. For Claude subscription billing, use a `passthrough: true` profile — normal claude, no tracking. [CLI delegation](#delegating-to-another-cli) instead bills the peer CLI's own subscription (ChatGPT or SuperGrok/X Premium+) through its cached local login, which gremlord invokes but never reads. That spend happens outside the router, so delegated runs appear in `gremlord cost` as $0 unpriced rows with estimated token counts and budgets cannot gate them.
+- **Fidelity.** Non-Anthropic models work through translation, but Claude Code's prompts and tool patterns are tuned for Claude, so expect them to be clunkier in the main loop. They shine as cheap workhorses for background tasks and subagents. Specific gaps: no `cache_control` breakpoints on OpenAI-dialect backends (provider-side implicit caching still shows up as cache reads, measurable with `gremlord cost`), thinking blocks are display-only, Anthropic server tools (web search, code execution) are unavailable on translated models, `top_k` is dropped, stop sequences truncate to four, and token counting for translated models is a deliberate ~15% overestimate so auto-compact fires early instead of overflowing context. Set `max_output` on models whose output cap is below what Claude Code requests (it asks for 32K), and `context_window` on models whose window differs from the ~200K Claude Code assumes (see [Context scaling](#context-scaling)).
 
 ## Subagents on any model
 
-Claude Code's built-in Agent tool takes a fixed `model` parameter (`sonnet | opus | haiku | fable`), so a routed alias like `qwen` can't be picked through it — subagents are stuck on the Claude tiers even when your best tool for the job is something else. A subagent *definition's* `model:` frontmatter has no such limit, and behind agentic's local endpoint Claude Code passes that string straight through, so agentic generates one subagent per configured model alias:
+Claude Code's built-in Agent tool takes a fixed `model` parameter (`sonnet | opus | haiku | fable`), so a routed alias like `qwen` can't be picked through it — subagents are stuck on the Claude tiers even when your best tool for the job is something else. A subagent *definition's* `model:` frontmatter has no such limit, and behind gremlord's local endpoint Claude Code passes that string straight through, so gremlord generates one subagent per configured model alias:
 
 ```bash
-agentic agents sync     # writes ~/.claude/agents/agentic-<alias>.md, one per model alias
-agentic agents list     # what's implied by your config, and what's pending
+gremlord agents sync     # writes ~/.claude/agents/gremlord-<alias>.md, one per model alias
+gremlord agents list     # what's implied by your config, and what's pending
 ```
 
-Every model you've configured becomes selectable by name — `subagent_type: "agentic-qwen"`, `"agentic-grok"`, `"agentic-gpt-5-6-sol"` — and its traffic routes, prices, and budgets like any other agentic request. The set is derived from your own `models:` map, so it's whatever *you* configured; nothing is hardcoded.
+Every model you've configured becomes selectable by name — `subagent_type: "gremlord-qwen"`, `"gremlord-grok"`, `"gremlord-gpt-5-6-sol"` — and its traffic routes, prices, and budgets like any other gremlord request. The set is derived from your own `models:` map, so it's whatever *you* configured; nothing is hardcoded.
 
-When your aliases change, the next `agentic` launch offers to refresh them (once — decline and it stays quiet until the aliases change again; `AGENTIC_NO_AGENT_SYNC=1` opts out entirely). Only files prefixed `agentic-` are ever written or removed, so your own subagents are never touched.
+When your aliases change, the next `gremlord` launch offers to refresh them (once — decline and it stays quiet until the aliases change again; `GREMLORD_NO_AGENT_SYNC=1` opts out entirely). Only files prefixed `gremlord-` are ever written or removed, so your own subagents are never touched.
 
 Aliases backed by a `cli` provider get a deliberately different description: the generated definition tells the orchestrator that it is handing the entire task to an independent agent with filesystem access, so it writes a self-contained prompt and expects minutes of latency instead of a completion.
 
@@ -319,27 +325,27 @@ If you already pay for ChatGPT or SuperGrok, a `cli` provider can delegate a who
 codex login                       # ChatGPT subscription
 # or: grok login                  # SuperGrok / X Premium+ subscription
 
-agentic providers add codex --type cli --dialect codex --sandbox workspace-write
-agentic models add codex --provider codex
-agentic agents sync               # writes ~/.claude/agents/agentic-codex.md
+gremlord providers add codex --type cli --dialect codex --sandbox workspace-write
+gremlord models add codex --provider codex
+gremlord agents sync               # writes ~/.claude/agents/gremlord-codex.md
 ```
 
-Invoking `subagent_type: "agentic-codex"` hands that task prompt verbatim to `codex exec` (or `grok -p`) in the session's working directory. The CLI authenticates itself from its own cached login; agentic neither extracts nor reuses its OAuth token. Set `--id` on the model alias only if you want to pass a specific model to the peer CLI. Use provider `--command` to override the binary and `--timeout-ms` to override the 20-minute default.
+Invoking `subagent_type: "gremlord-codex"` hands that task prompt verbatim to `codex exec` (or `grok -p`) in the session's working directory. The CLI authenticates itself from its own cached login; gremlord neither extracts nor reuses its OAuth token. Set `--id` on the model alias only if you want to pass a specific model to the peer CLI. Use provider `--command` to override the binary and `--timeout-ms` to override the 20-minute default.
 
 This is a whole agent loop, not a model completion: expect minutes of latency, no incremental output, and real file modifications. The delegated CLI sees only the one task prompt — no conversation history, system prompt, or Claude Code tool definitions — so make it self-contained. Its final message becomes the subagent result. Failures return as final message text instead of retryable stream errors, because silently repeating a filesystem-mutating run would be unsafe.
 
-Delegation is deliberately explicit-only. A `cli` alias cannot be a profile model, `small_fast`, tier, auto classifier, or task mapping. Bulk `agentic models test` also skips CLI aliases; name one explicitly (`agentic models test codex`) only when you intend to launch a real delegation.
+Delegation is deliberately explicit-only. A `cli` alias cannot be a profile model, `small_fast`, tier, auto classifier, or task mapping. Bulk `gremlord models test` also skips CLI aliases; name one explicitly (`gremlord models test codex`) only when you intend to launch a real delegation.
 
-For Codex, choose the blast radius with `--sandbox read-only`, `workspace-write`, or `danger-full-access`. Delegation requires an `agentic`-launched session so the router receives and validates its absolute working directory; a bare `claude` session is refused rather than running the CLI in the router leader's unrelated directory.
+For Codex, choose the blast radius with `--sandbox read-only`, `workspace-write`, or `danger-full-access`. Delegation requires an `gremlord`-launched session so the router receives and validates its absolute working directory; a bare `claude` session is refused rather than running the CLI in the router leader's unrelated directory.
 
 ## Finding another session
 
 Claude Code sessions can message each other, but addressing one is awkward: session names are auto-derived from whatever that session is doing (`daily-case-runtime`), so the name you'd actually say is the project directory — and `ListAgents`, the only thing that can mint the `[ref]` a cross-session `SendMessage` needs, doesn't show directories.
 
-`agentic peers` closes that gap by matching on both:
+`gremlord peers` closes that gap by matching on both:
 
 ```
-$ agentic peers labs-service-secondlife-be
+$ gremlord peers labs-service-secondlife-be
 Best match for "labs-service-secondlife-be":
   daily-case-runtime             busy  ~/code/secondlife/labs-service         started 12h ago
 
@@ -349,13 +355,13 @@ To message it: call ListAgents for its [ref], then SendMessage to
 
 With no argument it lists every session you can reach. Sessions on a build older than Claude Code 2.1.224 register no socket and are unreachable until restarted — they're reported as a count rather than silently omitted. When a query matches several sessions equally well, it says so instead of picking one.
 
-`agentic setup` writes this workflow into `~/.claude/CLAUDE.md`, between `<!-- agentic:peers:start -->` markers, so every session — agentic-launched or plain `claude` — knows to resolve names this way. Re-running setup refreshes that block and leaves the rest of the file alone.
+`gremlord setup` writes this workflow into `~/.claude/CLAUDE.md`, between `<!-- gremlord:peers:start -->` markers, so every session — gremlord-launched or plain `claude` — knows to resolve names this way. Re-running setup refreshes that block and leaves the rest of the file alone.
 
 ## Works with clauder
 
-agentic spawns `claude` directly and grants each session an auto-approved tool set for autonomous operation (`Read Write Edit Glob Grep Bash(*) WebFetch WebSearch mcp__clauder__*`). `--name` becomes claude's own session name.
+gremlord spawns `claude` directly and grants each session an auto-approved tool set for autonomous operation (`Read Write Edit Glob Grep Bash(*) WebFetch WebSearch mcp__clauder__*`). `--name` becomes claude's own session name.
 
-Cross-instance messaging is native to Claude Code — sessions register under `~/.claude/sessions` and reach each other over a peer socket — so agentic no longer launches through `clauder wrap`. See [Finding another session](#finding-another-session) for addressing them. [clauder](https://github.com/MaorBril/clauder) remains a useful companion for **persistent memory**, which it provides over its own MCP server registration and therefore works no matter how the session was started. The two tools are independent; each works without the other.
+Cross-instance messaging is native to Claude Code — sessions register under `~/.claude/sessions` and reach each other over a peer socket — so gremlord no longer launches through `clauder wrap`. See [Finding another session](#finding-another-session) for addressing them. [clauder](https://github.com/MaorBril/clauder) remains a useful companion for **persistent memory**, which it provides over its own MCP server registration and therefore works no matter how the session was started. The two tools are independent; each works without the other.
 
 `--no-clauder` is accepted but deprecated: every session is a bare claude now, so there is no wrap layer to opt out of.
 
@@ -363,32 +369,32 @@ Cross-instance messaging is native to Claude Code — sessions register under `~
 
 | Command | What it does |
 |---|---|
-| `agentic [-p profile] [--model alias] [-- args]` | launch Claude Code (args after `--` go to claude) |
-| `agentic setup` | first-run config, token, statusline + peer-guidance registration |
-| `agentic peers [name]` | find another Claude Code session to message |
-| `agentic cost [--week\|--month] [--by model\|profile\|session]` | spend report |
-| `agentic context [session-id]` | context-fullness trajectory (true vs reported tokens) |
-| `agentic eval run/report` | paired model evaluation and artifact report |
-| `agentic agents list/sync` | subagent definitions for your model aliases |
-| `agentic models add/list/remove/test/update-prices` | model aliases (`test` skips CLI aliases unless one is named explicitly) |
-| `agentic providers add/list/remove` | API providers and official CLI delegates (`--type cli`) |
-| `agentic profiles list/show` · `agentic budget set` | profiles and caps |
-| `agentic config get/set` | any config key |
-| `agentic router run/status` | headless router / who's leader |
-| `agentic doctor` | diagnose the installation |
-| `agentic update [--check]` | update agentic itself to the latest release |
+| `gremlord [-p profile] [--model alias] [-- args]` | launch Claude Code (args after `--` go to claude) |
+| `gremlord setup` | first-run config, token, statusline + peer-guidance registration |
+| `gremlord peers [name]` | find another Claude Code session to message |
+| `gremlord cost [--week\|--month] [--by model\|profile\|session]` | spend report |
+| `gremlord context [session-id]` | context-fullness trajectory (true vs reported tokens) |
+| `gremlord eval run/report` | paired model evaluation and artifact report |
+| `gremlord agents list/sync` | subagent definitions for your model aliases |
+| `gremlord models add/list/remove/test/update-prices` | model aliases (`test` skips CLI aliases unless one is named explicitly) |
+| `gremlord providers add/list/remove` | API providers and official CLI delegates (`--type cli`) |
+| `gremlord profiles list/show` · `gremlord budget set` | profiles and caps |
+| `gremlord config get/set` | any config key |
+| `gremlord router run/status` | headless router / who's leader |
+| `gremlord doctor` | diagnose the installation |
+| `gremlord update [--check]` | update gremlord itself to the latest release |
 
 ## Keys
 
-Provider keys are referenced by environment variable name. They resolve in order: process environment → `~/.agentic/env` (a `KEY=value` file, mode 0600, created by `setup`). Put keys in `~/.agentic/env` — the router reads it directly, so sessions work no matter which shell launched them, and the config file never holds a secret.
+Provider keys are referenced by environment variable name. They resolve in order: process environment → `~/.gremlord/env` (a `KEY=value` file, mode 0600, created by `setup`). Put keys in `~/.gremlord/env` — the router reads it directly, so sessions work no matter which shell launched them, and the config file never holds a secret.
 
-`cli` providers have no agentic key: `providers list` shows `· (subscription login)`, and `base_url` / `api_key_env` are rejected. Authentication belongs entirely to the official CLI.
+`cli` providers have no gremlord key: `providers list` shows `· (subscription login)`, and `base_url` / `api_key_env` are rejected. Authentication belongs entirely to the official CLI.
 
 ## Security notes
 
 The router binds `127.0.0.1` only and requires a per-install token (created by `setup`, mode 0600), so other local processes can't spend on your keys.
 
-CLI delegation starts a local subprocess with filesystem access in the launching session's working directory. The launcher carries that directory in `X-Agentic-Cwd`; the backend requires an absolute existing directory before spawning anything. Codex's `--sandbox` setting controls its write scope. Treat `danger-full-access` accordingly.
+CLI delegation starts a local subprocess with filesystem access in the launching session's working directory. The launcher carries that directory in `X-Gremlord-Cwd`; the backend requires an absolute existing directory before spawning anything. Codex's `--sandbox` setting controls its write scope. Treat `danger-full-access` accordingly.
 
 ## License
 

--- a/assets/hero-demo-home.sh
+++ b/assets/hero-demo-home.sh
@@ -7,15 +7,15 @@
 #   HOME="$DEMO_HOME" vhs assets/hero.tape
 #
 # ~/.claude is symlinked through to the real one, so the recorded `claude` looks
-# like a normal install; only agentic's own state (~/.agentic) is synthetic.
+# like a normal install; only gremlord's own state (~/.gremlord) is synthetic.
 # The router runs on its own port so it never disturbs live sessions.
 set -euo pipefail
 
 REAL_HOME="${REAL_HOME:-$HOME}"
-DEMO="${1:-$(mktemp -d -t agentic-hero)}"
-mkdir -p "$DEMO/.agentic"
+DEMO="${1:-$(mktemp -d -t gremlord-hero)}"
+mkdir -p "$DEMO/.gremlord"
 
-cat > "$DEMO/.agentic/config.yaml" <<'YAML'
+cat > "$DEMO/.gremlord/config.yaml" <<'YAML'
 version: 1
 default_profile: main
 router:
@@ -77,17 +77,17 @@ YAML
 
 # Real provider keys, so the KEY column is honest. They never render on screen —
 # `models list` prints only ✓/✗ — and this HOME is a throwaway outside the repo.
-if [ -f "$REAL_HOME/.agentic/env" ]; then
-    cp "$REAL_HOME/.agentic/env" "$DEMO/.agentic/env"
+if [ -f "$REAL_HOME/.gremlord/env" ]; then
+    cp "$REAL_HOME/.gremlord/env" "$DEMO/.gremlord/env"
 else
-    printf 'ANTHROPIC_API_KEY=demo\nOPENAI_API_KEY=demo\nXAI_API_KEY=demo\n' > "$DEMO/.agentic/env"
+    printf 'ANTHROPIC_API_KEY=demo\nOPENAI_API_KEY=demo\nXAI_API_KEY=demo\n' > "$DEMO/.gremlord/env"
 fi
-[ -f "$REAL_HOME/.agentic/token" ] && cp "$REAL_HOME/.agentic/token" "$DEMO/.agentic/token"
-chmod 600 "$DEMO/.agentic/config.yaml" "$DEMO/.agentic/env" "$DEMO/.agentic/token" 2>/dev/null || true
+[ -f "$REAL_HOME/.gremlord/token" ] && cp "$REAL_HOME/.gremlord/token" "$DEMO/.gremlord/token"
+chmod 600 "$DEMO/.gremlord/config.yaml" "$DEMO/.gremlord/env" "$DEMO/.gremlord/token" 2>/dev/null || true
 
 # Claude Code keeps its real config, so the splash is a normal install — but
 # with MCP servers dropped, since an unauthenticated one paints a warning across
-# the hero frame that has nothing to do with agentic.
+# the hero frame that has nothing to do with gremlord.
 ln -sfn "$REAL_HOME/.claude" "$DEMO/.claude"
 if [ -e "$REAL_HOME/.claude.json" ]; then
     python3 - "$REAL_HOME/.claude.json" "$DEMO/.claude.json" <<'PYEOF'
@@ -108,8 +108,8 @@ fi
 # A synthetic day: one aggregate row per model. Costs are computed from the
 # pricing above, so the breakdown is internally consistent.
 NOW=$(date +%s)
-rm -f "$DEMO/.agentic/agentic.db"
-sqlite3 "$DEMO/.agentic/agentic.db" <<SQL
+rm -f "$DEMO/.gremlord/agentic.db"
+sqlite3 "$DEMO/.gremlord/agentic.db" <<SQL
 CREATE TABLE usage_events (
   id                INTEGER PRIMARY KEY,
   ts                INTEGER NOT NULL,

--- a/assets/hero.tape
+++ b/assets/hero.tape
@@ -1,4 +1,4 @@
-# hero.gif — the 30-second agentic pitch: same claude, what it cost, on any model.
+# hero.gif — the 30-second gremlord pitch: same claude, what it cost, on any model.
 #
 # Record from the repo root against a throwaway HOME, so the demo shows a
 # synthetic usage log rather than the maintainer's real spend and providers.
@@ -27,11 +27,11 @@ Enter
 Show
 
 # 1. It is the claude you already know.
-Type "agentic"
+Type "gremlord"
 Enter
 Sleep 9s
 # Exit off-camera. Claude Code warns on stderr about any model name outside its
-# own catalog — which every agentic alias is, by design — and the warning only
+# own catalog — which every gremlord alias is, by design — and the warning only
 # becomes visible when the TUI tears down.
 Hide
 Type "/exit"
@@ -42,7 +42,7 @@ Enter
 Show
 
 # 2. ...that now tells you what today cost.
-Type "agentic cost --by model"
+Type "gremlord cost --by model"
 Enter
 Sleep 6s
 Hide
@@ -51,6 +51,6 @@ Enter
 Show
 
 # 3. ...on any model you point it at.
-Type "agentic models list"
+Type "gremlord models list"
 Enter
 Sleep 5s

--- a/cmd/agentscmd.go
+++ b/cmd/agentscmd.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/agents"
+	"github.com/gremlord/gremlord/internal/agents"
 )
 
 var agentsCmd = &cobra.Command{
@@ -16,11 +16,11 @@ var agentsCmd = &cobra.Command{
 	Long: `Claude Code's built-in Agent tool only accepts a fixed model parameter
 (sonnet | opus | haiku | fable), so a routed alias like "qwen" can't be
 selected through it. A subagent definition's model frontmatter has no such
-limit, so agentic generates one subagent per configured model alias —
-making every model selectable by name (subagent_type: "agentic-qwen").
+limit, so gremlord generates one subagent per configured model alias —
+making every model selectable by name (subagent_type: "gremlord-qwen").
 
-Definitions live in ~/.claude/agents/agentic-<alias>.md. Only files with the
-"agentic-" prefix are ever written or removed; your own agents are untouched.`,
+Definitions live in ~/.claude/agents/gremlord-<alias>.md. Only files with the
+"gremlord-" prefix are ever written or removed; your own agents are untouched.`,
 }
 
 var agentsListCmd = &cobra.Command{
@@ -37,7 +37,7 @@ var agentsListCmd = &cobra.Command{
 		}
 		want := agents.Desired(cfg)
 		if len(want) == 0 {
-			fmt.Println("no model aliases configured — add one with `agentic models add`")
+			fmt.Println("no model aliases configured — add one with `gremlord models add`")
 			return nil
 		}
 		changes, err := agents.Diff(cfg, dir)
@@ -66,7 +66,7 @@ var agentsListCmd = &cobra.Command{
 		tw.Flush()
 		fmt.Printf("\n%s\n", dir)
 		if len(changes) > 0 {
-			fmt.Println("run `agentic agents sync` to apply")
+			fmt.Println("run `gremlord agents sync` to apply")
 		}
 		return nil
 	},

--- a/cmd/configcmd.go
+++ b/cmd/configcmd.go
@@ -7,19 +7,21 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/launch"
-	"github.com/maorbril/agentic/internal/router"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/launch"
+	"github.com/gremlord/gremlord/internal/router"
+
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Read or edit ~/.agentic/config.yaml from the terminal",
+	Short: "Read or edit ~/.gremlord/config.yaml from the terminal",
 }
 
 var configGetCmd = &cobra.Command{
 	Use:   "get <dot.path>",
-	Short: "Print a config value (e.g. `agentic config get budgets.daily`)",
+	Short: "Print a config value (e.g. `gremlord config get budgets.daily`)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		doc, err := config.LoadDoc()
@@ -37,7 +39,7 @@ var configGetCmd = &cobra.Command{
 
 var configSetCmd = &cobra.Command{
 	Use:   "set <dot.path> <value>",
-	Short: "Set a config value (e.g. `agentic config set budgets.daily 25`)",
+	Short: "Set a config value (e.g. `gremlord config set budgets.daily 25`)",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return editConfig(func(doc *config.Doc) error { return doc.Set(args[0], args[1]) },
@@ -63,7 +65,8 @@ func editConfig(mutate func(*config.Doc) error, what string) error {
 	return nil
 }
 
-// reloadRouter best-effort POSTs /agentic/reload to the current leader.
+// reloadRouter best-effort POSTs the reload path to the current leader,
+// falling back to the pre-rename path when an agentic router holds the port.
 func reloadRouter() {
 	cfg, dataDir, err := loadConfig()
 	if err != nil {
@@ -76,19 +79,25 @@ func reloadRouter() {
 	if _, err := router.ReadDiscovery(dataDir); err != nil {
 		return // no leader running
 	}
-	req, err := http.NewRequest(http.MethodPost,
-		fmt.Sprintf("http://127.0.0.1:%d/agentic/reload", cfg.Router.Port), nil)
-	if err != nil {
-		return
-	}
-	req.Header.Set("x-api-key", token)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-	resp.Body.Close()
-	if resp.StatusCode == http.StatusNoContent {
-		fmt.Println("✓ live router reloaded")
+	for _, path := range []string{wire.PathReload, wire.LegacyPathReload} {
+		req, err := http.NewRequest(http.MethodPost,
+			fmt.Sprintf("http://127.0.0.1:%d%s", cfg.Router.Port, path), nil)
+		if err != nil {
+			return
+		}
+		req.Header.Set("x-api-key", token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusNoContent {
+			fmt.Println("✓ live router reloaded")
+			return
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			return
+		}
 	}
 }
 

--- a/cmd/contextcmd.go
+++ b/cmd/contextcmd.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 var contextJSON bool
@@ -22,14 +23,14 @@ var contextCmd = &cobra.Command{
 context window was versus what Claude Code's gauge saw. Use it to verify
 scaling behavior and to tune context_window / effective_context: sessions
 that error or degrade at high fullness argue for a lower effective_context.
-Defaults to the most recent session; find ids with 'agentic cost --by session'.`,
+Defaults to the most recent session; find ids with 'gremlord cost --by session'.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		_, dataDir, err := loadConfig()
 		if err != nil {
 			return err
 		}
-		st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db"))
+		st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName))
 		if err != nil {
 			return fmt.Errorf("no usage recorded yet (%v)", err)
 		}

--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 var (
@@ -28,7 +29,7 @@ var costCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db"))
+		st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName))
 		if err != nil {
 			return fmt.Errorf("no usage recorded yet (%v)", err)
 		}

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -18,7 +18,7 @@ func ensureClaude() bool {
 }
 
 // ensureClauder checks for the clauder binary and, if missing, offers to
-// install it. clauder is optional — agentic works without it, and since
+// install it. clauder is optional — gremlord works without it, and since
 // Claude Code gained native cross-instance messaging it is wanted only for
 // persistent memory.
 func ensureClauder() bool {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -73,6 +74,16 @@ var doctorCmd = &cobra.Command{
 		}
 
 		ensureClauder()
+
+		if dir, notCarried := config.LegacyLeftBehind(); dir != "" {
+			fmt.Printf("· %s is still on disk; gremlord reads %s now and left the original alone\n",
+				dir, dataDir)
+			if len(notCarried) > 0 {
+				fmt.Printf("  not carried over: %s\n", strings.Join(notCarried, ", "))
+				fmt.Println("  evals/ and swebench-venv/ embed absolute paths, so recreate the venv" +
+					" if you run SWE-bench; the logs regenerate. Delete the old directory when you are done with it.")
+			}
+		}
 
 		home, _ := os.UserHomeDir()
 		if data, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json")); err == nil {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/pricing"
-	"github.com/maorbril/agentic/internal/router"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/pricing"
+	"github.com/gremlord/gremlord/internal/router"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 var doctorCmd = &cobra.Command{
 	Use:   "doctor",
-	Short: "Diagnose the agentic installation",
+	Short: "Diagnose the gremlord installation",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fail := 0
 		check := func(ok bool, good, bad string) {
@@ -35,7 +35,7 @@ var doctorCmd = &cobra.Command{
 
 		cfg, cfgErr := config.Load()
 		if errors.Is(cfgErr, os.ErrNotExist) {
-			check(false, "", "no config — run `agentic setup`")
+			check(false, "", "no config — run `gremlord setup`")
 			return fmt.Errorf("%d problem(s)", fail)
 		}
 		check(cfgErr == nil, "config parses", fmt.Sprintf("config invalid: %v", cfgErr))
@@ -50,10 +50,10 @@ var doctorCmd = &cobra.Command{
 			}
 			check(p.Key() != "",
 				fmt.Sprintf("provider %s: %s available", name, p.APIKeyEnv),
-				fmt.Sprintf("provider %s: %s not in the environment or ~/.agentic/env", name, p.APIKeyEnv))
+				fmt.Sprintf("provider %s: %s not in the environment or ~/.gremlord/env", name, p.APIKeyEnv))
 		}
 
-		st, err := store.Open(filepath.Join(dataDir, "agentic.db"))
+		st, err := store.Open(filepath.Join(dataDir, config.DBName))
 		check(err == nil, "spend database writable", fmt.Sprintf("spend database: %v", err))
 		if err == nil {
 			st.Close()
@@ -63,7 +63,7 @@ var doctorCmd = &cobra.Command{
 		for alias, m := range cfg.Models {
 			check(prices.Has(m.ID),
 				fmt.Sprintf("model %s (%s) priced", alias, m.ID),
-				fmt.Sprintf("model %s (%s) has no pricing — spend will be untracked; add `pricing:` in config or run `agentic models update-prices`", alias, m.ID))
+				fmt.Sprintf("model %s (%s) has no pricing — spend will be untracked; add `pricing:` in config or run `gremlord models update-prices`", alias, m.ID))
 		}
 
 		if d, err := router.ReadDiscovery(dataDir); err == nil {
@@ -82,9 +82,9 @@ var doctorCmd = &cobra.Command{
 				} `json:"statusLine"`
 			}
 			json.Unmarshal(data, &s)
-			check(s.StatusLine.Command == "agentic statusline",
+			check(s.StatusLine.Command == "gremlord statusline",
 				"statusline registered",
-				"statusline not registered — run `agentic setup`")
+				"statusline not registered — run `gremlord setup`")
 		}
 
 		if os.Getenv("ANTHROPIC_API_KEY") != "" {

--- a/cmd/evalcmd.go
+++ b/cmd/evalcmd.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	evalpkg "github.com/maorbril/agentic/internal/eval"
+	"github.com/gremlord/gremlord/internal/config"
+	evalpkg "github.com/gremlord/gremlord/internal/eval"
 )
 
 var evalCmd = &cobra.Command{

--- a/cmd/models.go
+++ b/cmd/models.go
@@ -16,11 +16,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/launch"
-	"github.com/maorbril/agentic/internal/pricing"
-	"github.com/maorbril/agentic/internal/router"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/launch"
+	"github.com/gremlord/gremlord/internal/pricing"
+	"github.com/gremlord/gremlord/internal/router"
+
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 var modelsCmd = &cobra.Command{
@@ -80,10 +82,10 @@ var (
 var modelsAddCmd = &cobra.Command{
 	Use:   "add <alias>",
 	Short: "Add or update a model alias",
-	Example: `  agentic models add gpt  --provider openai --id gpt-5.2 --reasoning effort
-  agentic models add grok --provider xai --id grok-4
-  agentic models add qwen --provider local --id qwen3-coder-30b
-  agentic models add codex --provider codex`,
+	Example: `  gremlord models add gpt  --provider openai --id gpt-5.2 --reasoning effort
+  gremlord models add grok --provider xai --id grok-4
+  gremlord models add qwen --provider local --id qwen3-coder-30b
+  gremlord models add codex --provider codex`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if modelProvider == "" {
@@ -167,7 +169,7 @@ var modelsTestCmd = &cobra.Command{
 				continue
 			}
 			if !explicit && cfg.Providers[model.Provider].Type == config.ProviderCLI {
-				fmt.Printf("· %-12s (cli) — skipped; run %q to invoke it for real\n", alias, "agentic models test "+alias)
+				fmt.Printf("· %-12s (cli) — skipped; run %q to invoke it for real\n", alias, "gremlord models test "+alias)
 				continue
 			}
 			start := time.Now()
@@ -202,7 +204,8 @@ func probeModel(baseURL, token, alias string, timeout time.Duration) error {
 	req.Header.Set("x-api-key", token)
 	req.Header.Set("content-type", "application/json")
 	if cwd, err := os.Getwd(); err == nil {
-		req.Header.Set("X-Agentic-Cwd", cwd)
+		req.Header.Set(wire.HeaderCwd, cwd)
+		req.Header.Set(wire.LegacyHeaderCwd, cwd)
 	}
 	if timeout <= 0 {
 		timeout = 60 * time.Second
@@ -246,7 +249,7 @@ func ensureRouter(ctx context.Context, cfg *config.Config, dataDir string) (stri
 		return "", "", nil, err
 	}
 	port := cfg.Router.Port
-	// A router leader belongs to one agentic data directory/token. If another
+	// A router leader belongs to one gremlord data directory/token. If another
 	// install (most commonly a test with a temporary HOME) already owns the
 	// configured port, pick another local port rather than joining it and
 	// sending that unrelated leader our token/config.
@@ -268,7 +271,7 @@ func ensureRouter(ctx context.Context, cfg *config.Config, dataDir string) (stri
 	return mgr.BaseURL(), token, cancel, nil
 }
 
-const pricesURL = "https://raw.githubusercontent.com/maorbril/agentic/main/internal/pricing/prices.json"
+const pricesURL = "https://raw.githubusercontent.com/gremlord/gremlord/main/internal/pricing/prices.json"
 
 var modelsUpdatePricesCmd = &cobra.Command{
 	Use:   "update-prices",

--- a/cmd/peers.go
+++ b/cmd/peers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/peers"
+	"github.com/gremlord/gremlord/internal/peers"
 )
 
 var peersCmd = &cobra.Command{
@@ -69,7 +69,7 @@ SendMessage to "<name> [ref]".`,
 			if self != nil && len(peers.Match([]peers.Session{*self}, query)) > 0 {
 				return fmt.Errorf("%q is this session (%s) — nothing to message", query, self.Name)
 			}
-			return fmt.Errorf("no reachable session matches %q — run `agentic peers` to see them all", query)
+			return fmt.Errorf("no reachable session matches %q — run `gremlord peers` to see them all", query)
 		}
 
 		if query == "" {

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 	"gopkg.in/yaml.v3"
 )
 
@@ -92,7 +92,7 @@ var budgetShowCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db"))
+		st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName))
 		if err != nil {
 			return fmt.Errorf("no usage recorded yet (%v)", err)
 		}
@@ -135,7 +135,7 @@ var budgetShowCmd = &cobra.Command{
 		}
 
 		if cfg.Budgets == nil {
-			fmt.Println("No global budget set. Set one with: agentic budget set --daily 25 --monthly 400")
+			fmt.Println("No global budget set. Set one with: gremlord budget set --daily 25 --monthly 400")
 		} else {
 			printBudget("Global", cfg.Budgets, "")
 		}
@@ -152,8 +152,8 @@ var budgetShowCmd = &cobra.Command{
 var budgetSetCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set budget caps (global, or per profile with --profile)",
-	Example: `  agentic budget set --daily 25 --monthly 400
-  agentic budget set --profile cheap --daily 5`,
+	Example: `  gremlord budget set --daily 25 --monthly 400
+  gremlord budget set --profile cheap --daily 5`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		base := "budgets"
 		if budgetProfile != "" {

--- a/cmd/providers.go
+++ b/cmd/providers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 var (
@@ -71,16 +71,16 @@ var providersAddCmd = &cobra.Command{
 	Short: "Add or update a provider",
 	Long: `Add an upstream provider. Examples:
 
-  agentic providers add openai --type openai --base-url https://api.openai.com/v1 \
+  gremlord providers add openai --type openai --base-url https://api.openai.com/v1 \
       --key-env OPENAI_API_KEY --max-tokens-param max_completion_tokens
-  agentic providers add xai   --type openai --base-url https://api.x.ai/v1 --key-env XAI_API_KEY
-  agentic providers add local --type openai --base-url http://localhost:11434/v1 --key-env ""
+  gremlord providers add xai   --type openai --base-url https://api.x.ai/v1 --key-env XAI_API_KEY
+  gremlord providers add local --type openai --base-url http://localhost:11434/v1 --key-env ""
 
 A "cli" provider delegates whole tasks to a locally installed coding-agent
 CLI running under your own subscription login (codex login / grok login):
 
-  agentic providers add codex --type cli --dialect codex --sandbox workspace-write
-  agentic providers add grokcli --type cli --dialect grok`,
+  gremlord providers add codex --type cli --dialect codex --sandbox workspace-write
+  gremlord providers add grokcli --type cli --dialect grok`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if provType == config.ProviderCLI {

--- a/cmd/restartreport.go
+++ b/cmd/restartreport.go
@@ -8,9 +8,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/router"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/router"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 // printRestartReport lists what is still running an old binary after an
@@ -33,18 +33,18 @@ func printRestartReport(newTag string) {
 		case d.Version == newTag:
 			line += "  — already on the new version"
 		default:
-			line += "  — exits with its host session, or restart `agentic router run`"
+			line += "  — exits with its host session, or restart `gremlord router run`"
 		}
 		lines = append(lines, line)
 	}
 
-	if st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db")); err == nil {
+	if st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName)); err == nil {
 		defer st.Close()
 		sessions, _ := st.ActiveSessions()
 		const maxListed = 20
 		for i, s := range sessions {
 			if i == maxListed {
-				lines = append(lines, fmt.Sprintf("  … and %d more (see `agentic cost --by session`)", len(sessions)-maxListed))
+				lines = append(lines, fmt.Sprintf("  … and %d more (see `gremlord cost --by session`)", len(sessions)-maxListed))
 				break
 			}
 			line := fmt.Sprintf("  session %-28s profile %-10s %s  started %s",
@@ -65,7 +65,7 @@ func printRestartReport(newTag string) {
 		fmt.Println("Nothing is running the old version — new sessions pick up the update automatically.")
 		return
 	}
-	fmt.Printf("Still on the old binary until restarted (exit and re-run `agentic`):\n")
+	fmt.Printf("Still on the old binary until restarted (exit and re-run `gremlord`):\n")
 	for _, l := range lines {
 		fmt.Println(l)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Package cmd is the agentic CLI.
+// Package cmd is the gremlord CLI.
 package cmd
 
 import (
@@ -10,10 +10,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/launch"
-	"github.com/maorbril/agentic/internal/logrotate"
-	"github.com/maorbril/agentic/internal/router"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/launch"
+	"github.com/gremlord/gremlord/internal/logrotate"
+	"github.com/gremlord/gremlord/internal/router"
 )
 
 var (
@@ -25,9 +25,9 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "agentic [flags] [-- claude args...]",
+	Use:   "gremlord [flags] [-- claude args...]",
 	Short: "Multi-model, cost-controlled harness wrapping Claude Code",
-	Long: `agentic launches Claude Code through a local router that can serve
+	Long: `gremlord launches Claude Code through a local router that can serve
 Anthropic, OpenAI, xAI, and open-weight models, with budgets and spend
 tracking. Everything after -- is passed to claude verbatim.`,
 	Version:       router.Version,
@@ -54,7 +54,7 @@ tracking. Everything after -- is passed to claude verbatim.`,
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&flagProfile, "profile", "p", "", "profile from ~/.agentic/config.yaml")
+	rootCmd.Flags().StringVarP(&flagProfile, "profile", "p", "", "profile from ~/.gremlord/config.yaml")
 	rootCmd.Flags().StringVar(&flagModel, "model", "", "one-shot main-model alias override")
 	rootCmd.Flags().StringVar(&flagName, "name", "", "session name (forwarded to claude)")
 	rootCmd.Flags().BoolVar(&flagNoClauder, "no-clauder", false, "")
@@ -67,7 +67,7 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "agentic:", err)
+		fmt.Fprintln(os.Stderr, "gremlord:", err)
 		os.Exit(1)
 	}
 }
@@ -79,7 +79,7 @@ func loadConfig() (*config.Config, string, error) {
 	}
 	cfg, err := config.Load()
 	if errors.Is(err, os.ErrNotExist) {
-		return nil, "", fmt.Errorf("no config found — run `agentic setup` first")
+		return nil, "", fmt.Errorf("no config found — run `gremlord setup` first")
 	}
 	if err != nil {
 		return nil, "", err

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/launch"
-	"github.com/maorbril/agentic/internal/router"
+	"github.com/gremlord/gremlord/internal/launch"
+	"github.com/gremlord/gremlord/internal/router"
 )
 
 var routerCmd = &cobra.Command{
@@ -34,7 +34,7 @@ var routerRunCmd = &cobra.Command{
 		mgr := &router.Manager{Port: cfg.Router.Port, Token: token, DataDir: dataDir, Log: log}
 		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
-		fmt.Fprintf(os.Stderr, "agentic router on %s (ctrl-c to stop)\n", mgr.BaseURL())
+		fmt.Fprintf(os.Stderr, "gremlord router on %s (ctrl-c to stop)\n", mgr.BaseURL())
 		return mgr.Run(ctx)
 	},
 }

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 var (
@@ -32,7 +32,7 @@ var routingSetCmd = &cobra.Command{
 	Long: `A routing alias classifies each new user turn with a cheap model and
 dispatches it to a tier. Use it like any model: /model auto, or
 profiles: {model: auto}.`,
-	Example: `  agentic routing set auto --classifier haiku \
+	Example: `  gremlord routing set auto --classifier haiku \
       --deep opus --standard sonnet --light qwen \
       --task security_review=fable --task critical_review=opus`,
 	Args: cobra.ExactArgs(1),
@@ -131,7 +131,7 @@ var routingListCmd = &cobra.Command{
 			return err
 		}
 		if len(cfg.Routing) == 0 {
-			fmt.Println("no routing aliases — create one with `agentic routing set`")
+			fmt.Println("no routing aliases — create one with `gremlord routing set`")
 			return nil
 		}
 		tw := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/launch"
-	"github.com/maorbril/agentic/internal/peers"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/launch"
+	"github.com/gremlord/gremlord/internal/peers"
 )
 
 // registerStatusline merges a statusLine entry into ~/.claude/settings.json
@@ -32,15 +32,15 @@ func registerStatusline() error {
 		}
 	}
 	if existing, ok := settings["statusLine"]; ok {
-		if m, ok := existing.(map[string]any); ok && m["command"] == "agentic statusline" {
+		if m, ok := existing.(map[string]any); ok && m["command"] == "gremlord statusline" {
 			fmt.Println("✓ statusline already registered")
 			return nil
 		}
 		fmt.Println("· a statusline is already configured in ~/.claude/settings.json — leaving it alone")
-		fmt.Println(`  (to use agentic's: set "statusLine": {"type":"command","command":"agentic statusline"})`)
+		fmt.Println(`  (to use gremlord's: set "statusLine": {"type":"command","command":"gremlord statusline"})`)
 		return nil
 	}
-	settings["statusLine"] = map[string]any{"type": "command", "command": "agentic statusline"}
+	settings["statusLine"] = map[string]any{"type": "command", "command": "gremlord statusline"}
 	data, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
 		return err
@@ -48,12 +48,12 @@ func registerStatusline() error {
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		return err
 	}
-	fmt.Println("✓ registered agentic statusline in ~/.claude/settings.json")
+	fmt.Println("✓ registered gremlord statusline in ~/.claude/settings.json")
 	return nil
 }
 
-// registerPeerGuidance teaches every session — agentic-launched or not — how
-// to resolve an approximate session name via `agentic peers`. It lives in
+// registerPeerGuidance teaches every session — gremlord-launched or not — how
+// to resolve an approximate session name via `gremlord peers`. It lives in
 // ~/.claude/CLAUDE.md between markers, so re-running setup refreshes the block
 // without touching anything else in the file.
 func registerPeerGuidance() error {
@@ -77,7 +77,7 @@ func registerPeerGuidance() error {
 	return nil
 }
 
-const defaultConfig = `# ~/.agentic/config.yaml — edit directly or via the agentic CLI.
+const defaultConfig = `# ~/.gremlord/config.yaml — edit directly or via the gremlord CLI.
 version: 1
 default_profile: main
 
@@ -159,7 +159,7 @@ var setupCmd = &cobra.Command{
 
 		envPath := filepath.Join(dataDir, "env")
 		if _, err := os.Stat(envPath); os.IsNotExist(err) {
-			template := "# agentic provider keys (0600). The router reads this file directly,\n" +
+			template := "# gremlord provider keys (0600). The router reads this file directly,\n" +
 				"# so keys work no matter which shell launches a session.\n" +
 				"# Process environment variables take precedence when set.\n" +
 				"ANTHROPIC_API_KEY=\n" +
@@ -172,7 +172,7 @@ var setupCmd = &cobra.Command{
 		anthCfg := config.Provider{APIKeyEnv: "ANTHROPIC_API_KEY"}
 		if anthCfg.Key() == "" {
 			fmt.Println("⚠ ANTHROPIC_API_KEY not found — the router bills via API keys, not your Claude subscription.")
-			fmt.Printf("  Put it in %s (or export it), or use `agentic -p subscription` for normal subscription claude.\n", envPath)
+			fmt.Printf("  Put it in %s (or export it), or use `gremlord -p subscription` for normal subscription claude.\n", envPath)
 		} else {
 			fmt.Println("✓ ANTHROPIC_API_KEY available")
 		}
@@ -190,7 +190,7 @@ var setupCmd = &cobra.Command{
 			fmt.Println("  (cross-instance messaging is native to Claude Code — nothing to configure)")
 		}
 
-		fmt.Println("\nDone. Start a session with: agentic")
+		fmt.Println("\nDone. Start a session with: gremlord")
 		return nil
 	},
 }

--- a/cmd/statusline.go
+++ b/cmd/statusline.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 // statuslineCmd is invoked by Claude Code (registered as its statusLine
 // command) with session JSON on stdin. It inherits the session's env, so
-// AGENTIC_SESSION_ID / AGENTIC_PROFILE identify the session.
+// GREMLORD_SESSION_ID / GREMLORD_PROFILE identify the session (the
+// pre-rename AGENTIC_* spellings are still accepted).
 var statuslineCmd = &cobra.Command{
 	Use:    "statusline",
 	Short:  "Claude Code statusLine hook (spend bar)",
@@ -28,8 +29,8 @@ var statuslineCmd = &cobra.Command{
 		}
 		json.NewDecoder(os.Stdin).Decode(&input)
 
-		profile := os.Getenv("AGENTIC_PROFILE")
-		sessionID := os.Getenv("AGENTIC_SESSION_ID")
+		profile := config.Getenv("PROFILE")
+		sessionID := config.Getenv("SESSION_ID")
 		if sessionID == "" {
 			fmt.Printf("%s · sub · no tracking\n", orDefault(input.Model.DisplayName, "claude"))
 			return nil
@@ -39,7 +40,7 @@ var statuslineCmd = &cobra.Command{
 		if err != nil {
 			return nil // never break the statusline
 		}
-		st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db"))
+		st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName))
 		if err != nil {
 			return nil
 		}
@@ -68,7 +69,7 @@ var statuslineCmd = &cobra.Command{
 			goalReason = reason
 		}
 
-		fmt.Println(statusLine(orDefault(profile, "agentic"), modelPart, sess, day, cfg.Budgets, goalReason))
+		fmt.Println(statusLine(orDefault(profile, "gremlord"), modelPart, sess, day, cfg.Budgets, goalReason))
 		return nil
 	},
 }

--- a/cmd/statusline_test.go
+++ b/cmd/statusline_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // TestStatusLineBudgetSuffixAttachesToDaySpend guards against a regression

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -7,20 +7,20 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/maorbril/agentic/internal/clauder"
-	"github.com/maorbril/agentic/internal/router"
-	"github.com/maorbril/agentic/internal/selfupdate"
+	"github.com/gremlord/gremlord/internal/clauder"
+	"github.com/gremlord/gremlord/internal/router"
+	"github.com/gremlord/gremlord/internal/selfupdate"
 )
 
 var flagUpdateCheck bool
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "Update agentic itself to the latest release",
-	Long: `Checks GitHub for the latest agentic release and, if newer than the
+	Short: "Update gremlord itself to the latest release",
+	Long: `Checks GitHub for the latest gremlord release and, if newer than the
 running binary, downloads it and replaces the current executable in place.
 
-This updates agentic only — Claude Code updates itself independently.`,
+This updates gremlord only — Claude Code updates itself independently.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
@@ -33,15 +33,15 @@ This updates agentic only — Claude Code updates itself independently.`,
 		latest := strings.TrimPrefix(rel.TagName, "v")
 
 		if router.Version == "dev" {
-			fmt.Fprintln(os.Stderr, "agentic: running a dev build, version comparison skipped")
+			fmt.Fprintln(os.Stderr, "gremlord: running a dev build, version comparison skipped")
 		} else if current == latest {
-			fmt.Printf("agentic %s is already the latest version.\n", router.Version)
+			fmt.Printf("gremlord %s is already the latest version.\n", router.Version)
 			return nil
 		}
 
-		fmt.Printf("agentic %s -> %s\n", router.Version, rel.TagName)
+		fmt.Printf("gremlord %s -> %s\n", router.Version, rel.TagName)
 		if flagUpdateCheck {
-			fmt.Println("Run `agentic update` (without --check) to install.")
+			fmt.Println("Run `gremlord update` (without --check) to install.")
 			printRestartReport(rel.TagName)
 			return nil
 		}
@@ -70,9 +70,9 @@ This updates agentic only — Claude Code updates itself independently.`,
 		// is session-to-session only, with no CLI to reach it from out here,
 		// so we still notify through clauder — which registers instances from
 		// its MCP server and so sees sessions we no longer wrap.
-		msg := fmt.Sprintf("[agentic] agentic was updated to %s. If this session was launched via `agentic`, "+
+		msg := fmt.Sprintf("[gremlord] gremlord was updated to %s. If this session was launched via `gremlord`, "+
 			"its router is still running the old version — please tell the user this session should be "+
-			"restarted (exit and re-run `agentic`) at a convenient moment to pick up the update.", rel.TagName)
+			"restarted (exit and re-run `gremlord`) at a convenient moment to pick up the update.", rel.TagName)
 		if n := clauder.Broadcast(msg); n > 0 {
 			fmt.Printf("Notified %d running instance(s) via clauder to restart when convenient.\n", n)
 		}

--- a/docs/context-scaling.md
+++ b/docs/context-scaling.md
@@ -11,7 +11,7 @@ So the router lies to it — proportionally.
 
 ## How it works
 
-Every model can declare its real context size in `~/.agentic/config.yaml`:
+Every model can declare its real context size in `~/.gremlord/config.yaml`:
 
 ```yaml
 models:
@@ -138,7 +138,7 @@ Both behaviors are observable: the router logs `autoroute_size` (Debug) with
 the estimate, required tokens, excluded tiers, and the remap; `route_decisions`
 gains a `reason` column (`size:light→standard`, `size:sticky:light→standard`,
 `task:implementation`, or `task:sql_data:size-ineligible`) visible via the
-statusline and `agentic context`.
+statusline and `gremlord context`.
 
 **Request-body byte cap.** Separate from the token budget: some upstreams cap
 the raw request body size (e.g. an nginx `client_max_body_size`), and a body can
@@ -155,7 +155,7 @@ exceeds is filtered out before routing (so an image-heavy turn routes away from
 the capped provider), and a pre-dispatch guard refuses a body over the resolved
 provider's cap with a `400 invalid_request_error` ("request body too large … run
 /compact or remove images/attachments") instead of a mangled upstream 413 retry
-loop. Unknown cap (`0`) means no guard. `agentic providers add --max-request-bytes`
+loop. Unknown cap (`0`) means no guard. `gremlord providers add --max-request-bytes`
 sets it.
 
 ## Calibrating the estimator
@@ -187,7 +187,7 @@ Guards, because this feeds itself:
   should not outvote the large ones, and it is the large requests whose
   fit against a budget actually matters.
 
-`agentic context` prints the measured accuracy per model. A ratio of 0.80
+`gremlord context` prints the measured accuracy per model. A ratio of 0.80
 means the estimator over-counts by 25% and a fifth of every budget check
 was going to a number that was never there.
 
@@ -195,7 +195,7 @@ was going to a number that was never there.
 
 The same per-request record splits the estimate three ways — system
 prompt, tool schemas, conversation — because the first two are re-sent in
-full on every request whatever the turn is about. `agentic context` shows
+full on every request whatever the turn is about. `gremlord context` shows
 the average split and the fixed share; a session where tool schemas are
 40% of every request is one where trimming MCP servers buys more than any
 amount of routing cleverness.
@@ -251,7 +251,7 @@ Precedence runs most-immediate-first: `ENABLE_TOOL_SEARCH` in the
 launching shell (`false` for eager, `auto:N` to sample), then the
 profile's `tool_search`, then on.
 
-`agentic eval` pins the variable to `false` rather than inheriting it.
+`gremlord eval` pins the variable to `false` rather than inheriting it.
 Interactive sessions export `ENABLE_TOOL_SEARCH=true` and every command
 they run inherits it, so an eval launched from inside a session would
 defer while the same command from a plain terminal would not — and
@@ -260,7 +260,7 @@ on where it was invoked from. Flipping that is a deliberate re-baseline.
 
 ## Watching the prefix cache
 
-Prompt caching decides most of the input bill, so `agentic cost` reports
+Prompt caching decides most of the input bill, so `gremlord cost` reports
 the share of each model's input tokens that upstream served from cache.
 Translated backends get no `cache_control` breakpoints — that is an
 Anthropic-API concept — but provider-side implicit caching is prefix-based
@@ -286,7 +286,7 @@ Three layers, from cheap to real:
    go test ./internal/router/ -run TestContextScalingEval -v
    ```
 
-3. **Live sessions** (`agentic context [session-id]`): per-request
+3. **Live sessions** (`gremlord context [session-id]`): per-request
    trajectory of true tokens vs reported tokens vs budget, with compaction
    points marked. This is the research surface.
 
@@ -296,7 +296,7 @@ The nominal window is in the model card; the *effective* window is an
 empirical property you measure. Suggested loop:
 
 1. Start with `context_window` only (nominal). Run real sessions.
-2. Watch `agentic context` and the router log's `ctx_pct` field. Correlate
+2. Watch `gremlord context` and the router log's `ctx_pct` field. Correlate
    quality failures — wrong edits, forgotten instructions, tool-call
    flailing, upstream `4xx` at high fullness — with the fullness percentage
    at which they happened. The `err_type` column in the trajectory makes
@@ -311,7 +311,7 @@ empirical property you measure. Suggested loop:
    a starting point per model family, but local quantized builds often
    underperform their upstream numbers, so verify locally.)
 
-Queries against `~/.agentic/agentic.db` for aggregate research:
+Queries against `~/.gremlord/agentic.db` for aggregate research:
 
 ```sql
 -- error rate by context fullness decile, per model
@@ -342,7 +342,7 @@ GROUP BY model, decile ORDER BY model, decile;
   ```
 
   Avoid ids Claude Code treats as 1M (`[1m]` variants). Unknown aliases
-  still get correct *reporting* (gauge, statusline, `agentic context`) —
+  still get correct *reporting* (gauge, statusline, `gremlord context`) —
   they just won't trigger the client's compaction machinery.
 - **Leave real headroom under the trigger.** The observed trigger is the
   full assumed window (~200K reported), not the ~92% warning line — so at

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -17,4 +17,4 @@ double-counting it. Run it at least every 14 days or the gap is permanent.
 
 Two things these numbers are not. Clone counts include CI and scrapers, so they
 overstate humans. Release-asset downloads include the maintainer's own
-`agentic update` runs across every release, so early counts are mostly self-traffic.
+`gremlord update` runs across every release, so early counts are mostly self-traffic.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/maorbril/agentic
+module github.com/gremlord/gremlord
 
 go 1.26.3
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
-# agentic installer — downloads the latest release binary to ~/.local/bin.
+# gremlord installer — downloads the latest release binary to ~/.local/bin.
+# Formerly agentic; your config and cost history are carried over on first run.
 set -e
 
-REPO="maorbril/agentic"
-INSTALL_DIR="${AGENTIC_INSTALL_DIR:-$HOME/.local/bin}"
+REPO="gremlord/gremlord"
+# GREMLORD_INSTALL_DIR is the current name; AGENTIC_INSTALL_DIR still works
+# for one release so existing install scripts keep placing the binary.
+INSTALL_DIR="${GREMLORD_INSTALL_DIR:-${AGENTIC_INSTALL_DIR:-$HOME/.local/bin}}"
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 arch=$(uname -m)
@@ -59,14 +62,14 @@ if [ -z "$tag" ]; then
   exit 1
 fi
 
-asset="agentic-$os-$arch"
+asset="gremlord-$os-$arch"
 url="https://github.com/$REPO/releases/download/$tag/$asset"
 mkdir -p "$INSTALL_DIR"
 echo "Downloading $asset ($tag)..."
-curl -fsSL -o "$INSTALL_DIR/agentic" "$url"
-chmod +x "$INSTALL_DIR/agentic"
+curl -fsSL -o "$INSTALL_DIR/gremlord" "$url"
+chmod +x "$INSTALL_DIR/gremlord"
 
-echo "Installed agentic $tag to $INSTALL_DIR/agentic"
+echo "Installed gremlord $tag to $INSTALL_DIR/gremlord"
 case ":$PATH:" in
   *":$INSTALL_DIR:"*) ;;
   *) echo "NOTE: $INSTALL_DIR is not on your PATH — add it to your shell profile." ;;
@@ -75,4 +78,4 @@ esac
 prompt_install claude "claude CLI" https://claude.ai/install.sh bash
 prompt_install clauder "clauder (persistent memory, optional)" https://raw.githubusercontent.com/MaorBril/clauder/main/install.sh sh
 
-echo "Next: agentic setup"
+echo "Next: gremlord setup"

--- a/internal/agents/agents.go
+++ b/internal/agents/agents.go
@@ -5,10 +5,10 @@
 // model parameter (sonnet | opus | haiku | fable), so a routed alias like
 // "qwen" can never be selected through it. A subagent *definition's* model
 // frontmatter has no such restriction — and behind a custom
-// ANTHROPIC_BASE_URL (which agentic always sets) Claude Code passes the
+// ANTHROPIC_BASE_URL (which gremlord always sets) Claude Code passes the
 // string through unvalidated — so one generated definition per alias makes
 // every configured model selectable by name (subagent_type:
-// "agentic-qwen").
+// "gremlord-qwen").
 //
 // The alias list comes from the user's own config, so the generated set is
 // whatever that install has configured — nothing is hardcoded.
@@ -23,13 +23,18 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // Prefix marks the files this package owns. Anything without it in
 // ~/.claude/agents is a user's own agent and is never read, written, or
 // deleted.
-const Prefix = "agentic-"
+const Prefix = "gremlord-"
+
+// LegacyPrefix is the pre-rename prefix. Still recognised on scan, so a
+// sync reports the old files as removals and cleans them up; without this
+// they fall outside every scan and stay selectable forever.
+const LegacyPrefix = "agentic-"
 
 // Definition is one generated subagent file.
 type Definition struct {
@@ -82,11 +87,11 @@ func definitionFor(cfg *config.Config, alias string) Definition {
 
 	body := fmt.Sprintf(`---
 name: %s
-description: Runs the task on the %q model alias%s, routed through agentic. Use when you specifically want this model — for cost, context size, or capability reasons — rather than the default sonnet/opus/haiku tiers.
+description: Runs the task on the %q model alias%s, routed through gremlord. Use when you specifically want this model — for cost, context size, or capability reasons — rather than the default sonnet/opus/haiku tiers.
 model: %s
 ---
 
-You are running on the %q model alias, routed through the local agentic
+You are running on the %q model alias, routed through the local gremlord
 router to %s.
 
 Complete the task you were given and report the result. Your final message
@@ -188,9 +193,10 @@ type Change struct {
 	Kind string // "create" | "update" | "remove"
 }
 
-// Diff compares the definitions cfg implies against the agentic-* files on
-// disk. Files without Prefix are ignored entirely. A "remove" is reported
-// for an agentic-* file whose alias is no longer configured.
+// Diff compares the definitions cfg implies against the files on disk this
+// package owns. Anything else is ignored entirely. A "remove" is reported
+// for an owned file whose alias is no longer configured, and for every
+// pre-rename agentic-* file.
 func Diff(cfg *config.Config, dir string) ([]Change, error) {
 	want := map[string]Definition{}
 	for _, d := range Desired(cfg) {
@@ -204,7 +210,7 @@ func Diff(cfg *config.Config, dir string) ([]Change, error) {
 	}
 	for _, e := range entries {
 		name := e.Name()
-		if e.IsDir() || !strings.HasPrefix(name, Prefix) || !strings.HasSuffix(name, ".md") {
+		if e.IsDir() || !owned(name) || !strings.HasSuffix(name, ".md") {
 			continue // not ours
 		}
 		data, err := os.ReadFile(filepath.Join(dir, name))
@@ -238,8 +244,8 @@ func Diff(cfg *config.Config, dir string) ([]Change, error) {
 	return changes, nil
 }
 
-// Sync writes the definitions cfg implies and removes stale agentic-* files.
-// Only files carrying Prefix are ever written or deleted.
+// Sync writes the definitions cfg implies and removes stale files.
+// Only files carrying Prefix or LegacyPrefix are ever written or deleted.
 func Sync(cfg *config.Config, dir string) ([]Change, error) {
 	changes, err := Diff(cfg, dir)
 	if err != nil {
@@ -285,7 +291,7 @@ func Fingerprint(cfg *config.Config) string {
 }
 
 // declinedFile is where a declined fingerprint is remembered, inside the
-// agentic data dir (not ~/.claude — this is agentic's own state).
+// gremlord data dir (not ~/.claude — this is gremlord's own state).
 func declinedFile(dataDir string) string {
 	return filepath.Join(dataDir, "agents-declined")
 }
@@ -310,4 +316,10 @@ func RecordDeclined(dataDir, fingerprint string) error {
 // so a later change offers again).
 func ClearDeclined(dataDir string) {
 	os.Remove(declinedFile(dataDir))
+}
+
+// owned reports whether a filename is one this package manages, under either
+// the current or the pre-rename prefix.
+func owned(name string) bool {
+	return strings.HasPrefix(name, Prefix) || strings.HasPrefix(name, LegacyPrefix)
 }

--- a/internal/agents/agents_test.go
+++ b/internal/agents/agents_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func testCfg(aliases ...string) *config.Config {
@@ -44,13 +44,13 @@ func TestDesiredEmitsAliasAsModel(t *testing.T) {
 		t.Fatalf("got %d definitions, want 1", len(got))
 	}
 	d := got[0]
-	if d.Name != "agentic-gpt-5-6-sol" || d.Filename != "agentic-gpt-5-6-sol.md" {
+	if d.Name != "gremlord-gpt-5-6-sol" || d.Filename != "gremlord-gpt-5-6-sol.md" {
 		t.Errorf("name=%q file=%q", d.Name, d.Filename)
 	}
 	if !strings.Contains(d.Body, "\nmodel: gpt-5.6-sol\n") {
 		t.Errorf("body must carry the raw alias in model frontmatter:\n%s", d.Body)
 	}
-	if !strings.Contains(d.Body, "name: agentic-gpt-5-6-sol") {
+	if !strings.Contains(d.Body, "name: gremlord-gpt-5-6-sol") {
 		t.Errorf("body must declare the slugged name:\n%s", d.Body)
 	}
 }
@@ -126,19 +126,19 @@ func TestDiffAndSyncRoundTrip(t *testing.T) {
 	// Dropping an alias makes its file stale.
 	smaller := testCfg("qwen")
 	changes, _ = Diff(smaller, dir)
-	if len(changes) != 1 || changes[0].Kind != "remove" || changes[0].Name != "agentic-opus" {
-		t.Fatalf("want remove of agentic-opus, got %+v", changes)
+	if len(changes) != 1 || changes[0].Kind != "remove" || changes[0].Name != "gremlord-opus" {
+		t.Fatalf("want remove of gremlord-opus, got %+v", changes)
 	}
 	if _, err := Sync(smaller, dir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "agentic-opus.md")); !os.IsNotExist(err) {
-		t.Error("stale agentic-opus.md should have been removed")
+	if _, err := os.Stat(filepath.Join(dir, "gremlord-opus.md")); !os.IsNotExist(err) {
+		t.Error("stale gremlord-opus.md should have been removed")
 	}
 }
 
 // The safety property that matters most: a user's own agents are never read,
-// written, or deleted — only the agentic- prefix is owned.
+// written, or deleted — only the gremlord- prefix is owned.
 func TestSyncNeverTouchesForeignFiles(t *testing.T) {
 	dir := t.TempDir()
 	foreign := filepath.Join(dir, "my-reviewer.md")
@@ -165,7 +165,7 @@ func TestSyncNeverTouchesForeignFiles(t *testing.T) {
 	}
 }
 
-// A hand-edited agentic-* file is reported as an update so sync can restore
+// A hand-edited gremlord-* file is reported as an update so sync can restore
 // it — that file is ours by prefix.
 func TestDiffDetectsHandEditedOwnedFile(t *testing.T) {
 	dir := t.TempDir()
@@ -173,7 +173,7 @@ func TestDiffDetectsHandEditedOwnedFile(t *testing.T) {
 	if _, err := Sync(cfg, dir); err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(dir, "agentic-qwen.md")
+	path := filepath.Join(dir, "gremlord-qwen.md")
 	if err := os.WriteFile(path, []byte("tampered\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -232,4 +232,42 @@ func mustDiff(t *testing.T, cfg *config.Config, dir string) []Change {
 		t.Fatal(err)
 	}
 	return c
+}
+
+// After the rename, the agentic-* files a previous version wrote are orphans:
+// they still show up in Claude Code's subagent picker but point at the old
+// binary's naming. Sync has to delete them, which means the scan has to see
+// them even though they no longer carry the current prefix.
+func TestSyncRemovesPreRenameFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testCfg("qwen")
+
+	stale := filepath.Join(dir, LegacyPrefix+"opus.md")
+	if err := os.WriteFile(stale, []byte("old definition\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := Diff(cfg, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawRemove bool
+	for _, c := range changes {
+		if c.Kind == "remove" && c.Name == LegacyPrefix+"opus" {
+			sawRemove = true
+		}
+	}
+	if !sawRemove {
+		t.Fatalf("want a remove for %sopus, got %+v", LegacyPrefix, changes)
+	}
+
+	if _, err := Sync(cfg, dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("%s should have been removed", stale)
+	}
+	if _, err := os.Stat(filepath.Join(dir, Prefix+"qwen.md")); err != nil {
+		t.Errorf("current-prefix file missing: %v", err)
+	}
 }

--- a/internal/backend/anthropicbe/normalize.go
+++ b/internal/backend/anthropicbe/normalize.go
@@ -217,7 +217,7 @@ func sanitizeToolIDs(m map[string]any) {
 
 func validToolID(id string) string {
 	if id == "" {
-		return "toolu_agentic_missing"
+		return "toolu_gremlord_missing"
 	}
 	clean := true
 	for _, r := range id {

--- a/internal/backend/anthropicbe/passthrough.go
+++ b/internal/backend/anthropicbe/passthrough.go
@@ -12,9 +12,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 type Backend struct {
@@ -44,7 +44,7 @@ func (b *Backend) forward(ctx context.Context, call *backend.Call, w http.Respon
 		var err error
 		body, err = rewriteForModel(call.Raw, call.Route.Model.ID)
 		if err != nil {
-			anthropic.WriteError(w, 400, "invalid_request_error", "agentic: could not parse request body: "+err.Error())
+			anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: could not parse request body: "+err.Error())
 			return backend.Result{Status: 400, ErrType: "invalid_request_error"}
 		}
 	}
@@ -55,7 +55,7 @@ func (b *Backend) forward(ctx context.Context, call *backend.Call, w http.Respon
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 500, "api_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 500, ErrType: "api_error"}
 	}
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/backend/anthropicbe/passthrough_test.go
+++ b/internal/backend/anthropicbe/passthrough_test.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func mkCall(t *testing.T, body, baseURL, upstreamModel string) *backend.Call {

--- a/internal/backend/anthropicbe/scale.go
+++ b/internal/backend/anthropicbe/scale.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // The passthrough is byte-faithful by default and that is the whole point
-// of it — cache_control, signed thinking blocks, and fields agentic has
+// of it — cache_control, signed thinking blocks, and fields gremlord has
 // never heard of survive untouched. Scaling is the one deliberate
 // exception, and it stays off (factor 1) unless something asks for it:
 //

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // Call is one client request, carrying both the raw body (byte-faithful

--- a/internal/backend/call_test.go
+++ b/internal/backend/call_test.go
@@ -3,7 +3,7 @@ package backend
 import (
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func TestScaleBudgetPrefersGauge(t *testing.T) {

--- a/internal/backend/clibe/clibe.go
+++ b/internal/backend/clibe/clibe.go
@@ -1,6 +1,6 @@
 // Package clibe delegates a whole task to a locally installed coding-agent
 // CLI (Codex, Grok Build) running under the user's own subscription login.
-// agentic never sees the CLI's credentials — the binary authenticates itself
+// gremlord never sees the CLI's credentials — the binary authenticates itself
 // from its own cached login (`codex login` / `grok login`). The delegated CLI
 // runs its own independent agent loop with filesystem access in the calling
 // session's working directory, so a request here is minutes of autonomous
@@ -25,10 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
+
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 // CwdHeader carries the launching session's working directory on every
@@ -38,7 +40,7 @@ import (
 // same local trusted launch process and every request is gated by the
 // per-install token, so this is not a cross-trust boundary; the backend still
 // validates it (absolute, existing directory) as defense against bugs.
-const CwdHeader = "X-Agentic-Cwd"
+const CwdHeader = wire.HeaderCwd
 
 const (
 	defaultTimeout   = 20 * time.Minute
@@ -97,9 +99,9 @@ func New() *Backend {
 func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
 	prov := call.Route.Provider
 
-	cwd := call.Header.Get(CwdHeader)
+	cwd := wire.Cwd(call.Header)
 	if cwd == "" || !filepath.IsAbs(cwd) {
-		return refuse(w, "cli delegation needs the session working directory (launch via `agentic` so "+CwdHeader+" is set)")
+		return refuse(w, "cli delegation needs the session working directory (launch via `gremlord` so "+CwdHeader+" is set)")
 	}
 	if st, err := os.Stat(cwd); err != nil || !st.IsDir() {
 		return refuse(w, fmt.Sprintf("cli delegation working directory %q is not an existing directory", cwd))
@@ -141,7 +143,7 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 		if err := sse.Event("message_start", map[string]any{
 			"type": "message_start",
 			"message": anthropic.MessagesResponse{
-				ID: "msg_agentic_cli", Type: "message", Role: "assistant",
+				ID: "msg_gremlord_cli", Type: "message", Role: "assistant",
 				Model: call.Route.Alias, Content: []anthropic.ContentBlock{},
 				Usage: anthropic.Usage{InputTokens: estIn},
 			},
@@ -199,23 +201,23 @@ wait:
 	res := backend.Result{Status: 200}
 	switch {
 	case timedOut || errors.Is(runErr, context.DeadlineExceeded):
-		text = fmt.Sprintf("agentic: %s delegation timed out after %s; partial changes may exist in %s", prov.Dialect, timeout, cwd)
+		text = fmt.Sprintf("gremlord: %s delegation timed out after %s; partial changes may exist in %s", prov.Dialect, timeout, cwd)
 		res.ErrType, res.ErrMsg = "api_error", "delegation timeout"
 	case runErr != nil:
 		msg := runErr.Error()
 		if tail := stderr.String(); tail != "" {
 			msg += ": " + tail
 		}
-		text = fmt.Sprintf("agentic: %s delegation failed (%s)", prov.Dialect, msg)
+		text = fmt.Sprintf("gremlord: %s delegation failed (%s)", prov.Dialect, msg)
 		res.ErrType, res.ErrMsg = "api_error", truncate(msg, 512)
 	case text == "":
-		text = fmt.Sprintf("agentic: %s delegation produced no output", prov.Dialect)
+		text = fmt.Sprintf("gremlord: %s delegation produced no output", prov.Dialect)
 		res.ErrType, res.ErrMsg = "api_error", "empty delegation output"
 	}
 	if stdout.truncated {
-		text += "\n\nagentic: stdout truncated at 1MiB"
+		text += "\n\ngremlord: stdout truncated at 1MiB"
 	}
-	// Heuristic usage so the delegation shows up in `agentic cost` as a $0
+	// Heuristic usage so the delegation shows up in `gremlord cost` as a $0
 	// unpriced row (validation forbids pricing on cli models).
 	res.Usage = anthropic.Usage{InputTokens: estIn, OutputTokens: estimateTokens(text)}
 	res.ReportedInput = estIn
@@ -240,7 +242,7 @@ wait:
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(anthropic.MessagesResponse{
-		ID: "msg_agentic_cli", Type: "message", Role: "assistant",
+		ID: "msg_gremlord_cli", Type: "message", Role: "assistant",
 		Model:      call.Route.Alias,
 		Content:    []anthropic.ContentBlock{{Type: "text", Text: text}},
 		StopReason: "end_turn",
@@ -254,7 +256,7 @@ wait:
 func (b *Backend) CountTokens(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
 	req, err := anthropic.ParseRequest(call.Raw)
 	if err != nil {
-		anthropic.WriteError(w, 400, "invalid_request_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 400, ErrType: "invalid_request_error"}
 	}
 	n := tokens.ScaleCount(call.EstimateInput(req), tokens.ScaleFactor(call.ScaleBudget()))
@@ -268,7 +270,7 @@ func (b *Backend) CountTokens(ctx context.Context, call *backend.Call, w http.Re
 // surfaces 400s verbatim instead of retry-spinning, and retrying a
 // side-effectful agent run is worse than retrying a completion.
 func refuse(w http.ResponseWriter, msg string) backend.Result {
-	full := "agentic: " + msg
+	full := "gremlord: " + msg
 	anthropic.WriteError(w, 400, "invalid_request_error", full)
 	return backend.Result{Status: 400, ErrType: "invalid_request_error", ErrMsg: truncate(msg, 512)}
 }
@@ -280,7 +282,7 @@ func (b *Backend) environ() []string {
 	return os.Environ()
 }
 
-// sanitizeEnv drops agentic/router credentials and unrelated provider keys
+// sanitizeEnv drops gremlord/router credentials and unrelated provider keys
 // from the delegated process. The peer CLI authenticates itself from its own
 // login; it does not need the launcher's secrets.
 func sanitizeEnv(env []string) []string {
@@ -292,6 +294,8 @@ func sanitizeEnv(env []string) []string {
 		"ANTHROPIC_MODEL":            true,
 		"ANTHROPIC_SMALL_FAST_MODEL": true,
 		"CLAUDE_CODE_SUBAGENT_MODEL": true,
+		"GREMLORD_SESSION_ID":        true,
+		"GREMLORD_PROFILE":           true,
 		"AGENTIC_SESSION_ID":         true,
 		"AGENTIC_PROFILE":            true,
 		"OPENAI_API_KEY":             true,

--- a/internal/backend/clibe/clibe_test.go
+++ b/internal/backend/clibe/clibe_test.go
@@ -14,9 +14,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 type fakeExecutor struct {

--- a/internal/backend/openaibe/backend.go
+++ b/internal/backend/openaibe/backend.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/openai"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/openai"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 type Backend struct {
@@ -26,24 +26,24 @@ func New() *Backend {
 func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
 	req, err := anthropic.ParseRequest(call.Raw)
 	if err != nil {
-		anthropic.WriteError(w, 400, "invalid_request_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 400, ErrType: "invalid_request_error"}
 	}
 	chatReq, err := TranslateRequest(req, call.Route)
 	if err != nil {
-		anthropic.WriteError(w, 400, "invalid_request_error", "agentic translate: "+err.Error())
+		anthropic.WriteError(w, 400, "invalid_request_error", "gremlord translate: "+err.Error())
 		return backend.Result{Status: 400, ErrType: "invalid_request_error"}
 	}
 	body, err := json.Marshal(chatReq)
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 500, "api_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 500, ErrType: "api_error"}
 	}
 
 	u := strings.TrimSuffix(call.Route.Provider.BaseURL, "/") + "/chat/completions"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 500, "api_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 500, ErrType: "api_error"}
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
@@ -84,19 +84,19 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		msg := "agentic: reading upstream body: " + err.Error()
+		msg := "gremlord: reading upstream body: " + err.Error()
 		anthropic.WriteError(w, 500, "api_error", msg)
 		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	var parsed openai.ChatResponse
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		msg := "agentic: upstream body unparseable: " + err.Error()
+		msg := "gremlord: upstream body unparseable: " + err.Error()
 		anthropic.WriteError(w, 500, "api_error", msg)
 		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
 	out, err := TranslateResponse(&parsed, call.Envelope.Model)
 	if err != nil {
-		msg := "agentic translate: " + err.Error()
+		msg := "gremlord translate: " + err.Error()
 		anthropic.WriteError(w, 500, "api_error", msg)
 		return backend.Result{Status: 502, ErrType: "api_error", ErrMsg: msg}
 	}
@@ -113,7 +113,7 @@ func (b *Backend) Messages(ctx context.Context, call *backend.Call, w http.Respo
 func (b *Backend) CountTokens(ctx context.Context, call *backend.Call, w http.ResponseWriter) backend.Result {
 	req, err := anthropic.ParseRequest(call.Raw)
 	if err != nil {
-		anthropic.WriteError(w, 400, "invalid_request_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: "+err.Error())
 		return backend.Result{Status: 400, ErrType: "invalid_request_error"}
 	}
 	n := tokens.ScaleCount(call.EstimateInput(req), tokens.ScaleFactor(call.ScaleBudget()))

--- a/internal/backend/openaibe/backend_test.go
+++ b/internal/backend/openaibe/backend_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 const minimalReq = `{"model":"gpt","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}`

--- a/internal/backend/openaibe/request.go
+++ b/internal/backend/openaibe/request.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/openai"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/openai"
 )
 
 // maxToolCallsPerMessage is OpenAI's hard cap on messages[].tool_calls

--- a/internal/backend/openaibe/response.go
+++ b/internal/backend/openaibe/response.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/openai"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/openai"
 )
 
 // TranslateResponse maps a non-streaming ChatResponse back to the
@@ -20,7 +20,7 @@ func TranslateResponse(resp *openai.ChatResponse, alias string) (*anthropic.Mess
 		Model: alias,
 	}
 	if out.ID == "msg_" {
-		out.ID = "msg_agentic"
+		out.ID = "msg_gremlord"
 	}
 	if len(resp.Choices) == 0 {
 		return nil, fmt.Errorf("upstream returned no choices")
@@ -59,7 +59,7 @@ func reasoningText(deepseek, openrouter string) string {
 
 func toolUseID(id string) string {
 	if id == "" {
-		return "toolu_agentic_missing"
+		return "toolu_gremlord_missing"
 	}
 	return sanitizeToolUseID(id)
 }

--- a/internal/backend/openaibe/stream.go
+++ b/internal/backend/openaibe/stream.go
@@ -9,9 +9,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/openai"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/openai"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // streamState turns an OpenAI chunk stream into the exact Anthropic SSE
@@ -141,7 +141,7 @@ func (s *streamState) Run(ctx context.Context, body io.Reader) (anthropic.Usage,
 // the message is opened with a synthetic id (handleChunk won't re-open it).
 func (s *streamState) ping() {
 	if !s.started {
-		s.startMessage("msg_agentic_pending")
+		s.startMessage("msg_gremlord_pending")
 		return // startMessage already pings
 	}
 	s.sse.Ping()
@@ -257,7 +257,7 @@ func (s *streamState) currentToolID() string {
 func (s *streamState) openToolBlock() {
 	id := s.pendingID
 	if id == "" {
-		id = "toolu_agentic_missing"
+		id = "toolu_gremlord_missing"
 	} else {
 		id = sanitizeToolUseID(id)
 	}

--- a/internal/backend/openaibe/stream_test.go
+++ b/internal/backend/openaibe/stream_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/anthropic"
 )
 
 // runStream feeds recorded OpenAI chunks through the state machine and

--- a/internal/backend/openaibe/translate_test.go
+++ b/internal/backend/openaibe/translate_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/openai"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/openai"
 )
 
 func route(maxTokensParam, reasoning string) config.Resolved {
@@ -254,7 +254,7 @@ func TestToolUseIDSanitizesInvalidCharacters(t *testing.T) {
 		"TaskOutput:12":               "TaskOutput_12",
 		"call_a":                      "call_a",
 		"toolu_1":                     "toolu_1",
-		"":                            "toolu_agentic_missing",
+		"":                            "toolu_gremlord_missing",
 		"functions.read_file:0":       "functions_read_file_0",
 		"mcp__clauder__get_context:0": "mcp__clauder__get_context_0",
 	}

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -8,8 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 // Gate holds in-memory spend counters (rebuilt from SQLite on start and on
@@ -80,7 +80,7 @@ func (g *Gate) Check(profile string) string {
 				continue
 			}
 			if win.spent >= win.cap && hardStop(s.budget) {
-				return fmt.Sprintf("[agentic] %s budget exceeded ($%.2f of $%.2f for %s). Raise it in ~/.agentic/config.yaml or run: agentic cost",
+				return fmt.Sprintf("[gremlord] %s budget exceeded ($%.2f of $%.2f for %s). Raise it in ~/.gremlord/config.yaml or run: gremlord cost",
 					win.name, win.spent, win.cap, s.label)
 			}
 			warnAt := s.budget.WarnAt

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Package config loads and validates ~/.agentic/config.yaml.
+// Package config loads and validates ~/.gremlord/config.yaml.
 package config
 
 import (
@@ -15,7 +15,7 @@ const (
 	ProviderOpenAI    = "openai"
 	// ProviderCLI delegates to a locally installed coding-agent CLI (Codex,
 	// Grok Build) running under the user's own subscription login, instead of
-	// an HTTP endpoint. agentic never touches the CLI's credentials — the
+	// an HTTP endpoint. gremlord never touches the CLI's credentials — the
 	// binary authenticates itself from its own cached login.
 	ProviderCLI = "cli"
 
@@ -146,7 +146,7 @@ func (p Provider) Bin() string {
 }
 
 // Key resolves the provider's API key: config literal, then process
-// environment, then ~/.agentic/env (so keys don't depend on which shell
+// environment, then ~/.gremlord/env (so keys don't depend on which shell
 // launched the router leader). Empty is valid for unauthenticated local
 // endpoints.
 func (p Provider) Key() string {
@@ -247,13 +247,23 @@ type Price struct {
 	CacheWrite float64 `yaml:"cache_write" json:"cache_write"`
 }
 
-// DataDir returns ~/.agentic, creating it if needed.
+// DataDir returns ~/.gremlord, creating it if needed. On the first run after
+// the gremlord rename it carries the old directory's contents across.
 func DataDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, ".agentic")
+	dir := filepath.Join(home, DirName)
+
+	// A failed migration must not make the tool unusable. Warn and continue
+	// with an empty directory; ~/.agentic is untouched, so a retry is possible.
+	if migrated, err := migrateLegacy(home, dir); err != nil {
+		fmt.Fprintf(os.Stderr, "gremlord: could not carry ~/%s forward: %v\n", LegacyDirName, err)
+	} else if migrated {
+		fmt.Fprintf(os.Stderr, "gremlord: carried your config and cost history over from ~/%s (originals untouched; `gremlord doctor` lists what was not copied)\n", LegacyDirName)
+	}
+
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
@@ -269,13 +279,13 @@ func Path() (string, error) {
 }
 
 // Load reads and validates the config file. A missing file returns
-// os.ErrNotExist so callers can suggest `agentic setup`.
+// os.ErrNotExist so callers can suggest `gremlord setup`.
 func Load() (*Config, error) {
 	path, err := Path()
 	if err != nil {
 		return nil, err
 	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(readPath(path))
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +384,7 @@ func (c *Config) Validate() error {
 	for name, prof := range c.Profiles {
 		for what, alias := range map[string]string{"model": prof.Model, "small_fast": prof.SmallFast} {
 			if alias != "" && c.IsCLIAlias(alias) {
-				return fmt.Errorf("config: profile %q %s references cli alias %q — cli delegation is only available as an explicit subagent (agentic agents sync), not a session model", name, what, alias)
+				return fmt.Errorf("config: profile %q %s references cli alias %q — cli delegation is only available as an explicit subagent (gremlord agents sync), not a session model", name, what, alias)
 			}
 		}
 		for tier, alias := range prof.Tiers {

--- a/internal/config/envfile.go
+++ b/internal/config/envfile.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// ~/.agentic/env holds KEY=VALUE lines (0600) so provider keys don't
+// ~/.gremlord/env holds KEY=VALUE lines (0600) so provider keys don't
 // depend on which shell happened to launch the router leader. Process
 // environment still wins when set.
 
@@ -19,13 +19,13 @@ var envFile struct {
 	values map[string]string
 }
 
-// EnvFileLookup returns the value for name from ~/.agentic/env, or "".
+// EnvFileLookup returns the value for name from ~/.gremlord/env, or "".
 func EnvFileLookup(name string) string {
 	dir, err := DataDir()
 	if err != nil {
 		return ""
 	}
-	path := filepath.Join(dir, "env")
+	path := readPath(filepath.Join(dir, "env"))
 
 	envFile.mu.Lock()
 	defer envFile.mu.Unlock()

--- a/internal/config/envfile_test.go
+++ b/internal/config/envfile_test.go
@@ -9,7 +9,7 @@ import (
 func TestKeyResolutionOrder(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	dir := filepath.Join(home, ".agentic")
+	dir := filepath.Join(home, ".gremlord")
 	os.MkdirAll(dir, 0o700)
 	os.WriteFile(filepath.Join(dir, "env"), []byte(
 		"# comment\nTEST_AGENTIC_KEY=from-file\nQUOTED_KEY=\"quoted-value\"\n"), 0o600)

--- a/internal/config/envvar.go
+++ b/internal/config/envvar.go
@@ -1,0 +1,33 @@
+package config
+
+import "os"
+
+const (
+	// EnvPrefix namespaces gremlord's own environment variables.
+	EnvPrefix = "GREMLORD_"
+
+	// LegacyEnvPrefix is the pre-rename prefix, still read for one release.
+	// A session launched by an older agentic binary — or a statusline hook in
+	// ~/.claude/settings.json still pointing at the old executable — would
+	// otherwise lose its session identity and silently stop tracking spend.
+	LegacyEnvPrefix = "AGENTIC_"
+)
+
+// EnvName returns the current name of one of gremlord's variables.
+func EnvName(suffix string) string { return EnvPrefix + suffix }
+
+// Getenv reads GREMLORD_<suffix>, falling back to AGENTIC_<suffix>. The new
+// spelling wins when both are set, so a half-migrated environment resolves to
+// whichever launcher ran most recently rather than to a stale value.
+func Getenv(suffix string) string {
+	if v := os.Getenv(EnvPrefix + suffix); v != "" {
+		return v
+	}
+	return os.Getenv(LegacyEnvPrefix + suffix)
+}
+
+// EnvNames returns both spellings, for code that has to strip gremlord's own
+// variables out of a child process's environment.
+func EnvNames(suffix string) []string {
+	return []string{EnvPrefix + suffix, LegacyEnvPrefix + suffix}
+}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -142,3 +142,24 @@ func readPath(path string) string {
 	}
 	return path
 }
+
+// LegacyLeftBehind describes an agentic directory still on disk and what the
+// migration deliberately did not carry across. Empty when there is nothing to
+// say. The first-run notice points users at `gremlord doctor` for this, so the
+// two have to stay in step.
+func LegacyLeftBehind() (dir string, notCarried []string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", nil
+	}
+	dir = filepath.Join(home, LegacyDirName)
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return "", nil
+	}
+	for _, name := range []string{"evals", "swebench-venv", "router.log", "router.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			notCarried = append(notCarried, name)
+		}
+	}
+	return dir, notCarried
+}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const (
+	// DirName is where gremlord keeps config, keys, and the cost log.
+	DirName = ".gremlord"
+
+	// LegacyDirName is the pre-rename directory. Read once, to carry a v0.1.x
+	// gremlord install forward; never written to.
+	LegacyDirName = ".agentic"
+
+	// DBName deliberately keeps its pre-rename name. SQLite keeps -wal and
+	// -shm sidecars beside the main file, and renaming only the main file
+	// orphans the write-ahead log — which is exactly the cost history the
+	// migration exists to preserve.
+	DBName = "agentic.db"
+)
+
+// carried is what moves from an agentic install to a gremlord one.
+//
+// Deliberately not carried:
+//   - router.json — leader discovery for a router that is gone by now; a stale
+//     copy would point the new binary at a dead port.
+//   - router.log* — a rotating log that regenerates on the next request.
+//   - evals/, swebench-venv/ — hundreds of megabytes between them, and both
+//     embed absolute paths (a Python venv does not survive being moved), so
+//     copying would duplicate a lot of disk to produce something broken.
+var carried = []string{
+	"config.yaml",
+	"env",
+	"token",
+	"prices.json",
+	DBName,
+	DBName + "-wal",
+	DBName + "-shm",
+}
+
+// migrateLegacy copies an agentic data directory into its gremlord equivalent
+// the first time the renamed binary runs. The original is left untouched, so a
+// user can go back to the old binary with their history intact.
+//
+// The copy lands in a temp directory and is renamed into place, so two
+// processes starting at once cannot interleave a half-copied directory: one
+// rename wins and the loser sees a directory that already exists.
+func migrateLegacy(home, dir string) (bool, error) {
+	if _, err := os.Stat(dir); err == nil {
+		return false, nil // already on gremlord
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	legacy := filepath.Join(home, LegacyDirName)
+	if info, err := os.Stat(legacy); err != nil || !info.IsDir() {
+		return false, nil // nothing to carry over
+	}
+
+	staging, err := os.MkdirTemp(home, ".gremlord-migrating-*")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(staging)
+	if err := os.Chmod(staging, 0o700); err != nil {
+		return false, err
+	}
+
+	copied := 0
+	for _, name := range carried {
+		src := filepath.Join(legacy, name)
+		if _, err := os.Stat(src); err != nil {
+			continue // optional file this install never created
+		}
+		if err := copyFile(src, filepath.Join(staging, name)); err != nil {
+			return false, fmt.Errorf("copy %s: %w", name, err)
+		}
+		copied++
+	}
+	if copied == 0 {
+		return false, nil // an empty or unrelated ~/.agentic
+	}
+
+	if err := os.Rename(staging, dir); err != nil {
+		// Lost the race with another process, which is a success for us.
+		if _, statErr := os.Stat(dir); statErr == nil {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// copyFile copies one file, preserving its mode so key material stays 0600.
+func copyFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// readPath resolves a file for reading, preferring the gremlord directory and
+// falling back to the same filename under ~/.agentic.
+//
+// migrateLegacy normally copies these on first run, so this only matters when
+// the copy could not complete — an unwritable home, a full disk, a permissions
+// problem. Without the fallback such a user silently loses their config and
+// provider keys and gets defaults instead, which for a tool holding API keys
+// and budgets is a much worse failure than reading the old location.
+//
+// Reads only. Writes always go to the gremlord directory, so the old files are
+// never modified and the tool converges on the new location.
+func readPath(path string) string {
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	legacy := filepath.Join(home, LegacyDirName, filepath.Base(path))
+	if _, err := os.Stat(legacy); err == nil {
+		return legacy
+	}
+	return path
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A v0.1.x agentic install must come across intact, and the original must be
+// left exactly as it was so the old binary still works.
+func TestMigrateLegacyCarriesConfigAndHistory(t *testing.T) {
+	home := t.TempDir()
+	legacy := filepath.Join(home, LegacyDirName)
+	if err := os.MkdirAll(filepath.Join(legacy, "evals", "run-1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, body string, mode os.FileMode) {
+		if err := os.WriteFile(filepath.Join(legacy, name), []byte(body), mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("config.yaml", "version: 1\n", 0o600)
+	write("env", "ANTHROPIC_API_KEY=secret\n", 0o600)
+	write("token", "tok\n", 0o600)
+	write(DBName, "sqlite-bytes", 0o644)
+	write(DBName+"-wal", "wal-bytes", 0o644)
+	write("router.log", "noise\n", 0o644)
+	write("router.json", `{"port":41100}`, 0o600)
+	if err := os.WriteFile(filepath.Join(legacy, "evals", "run-1", "artifact"), []byte("big"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(home, DirName)
+	migrated, err := migrateLegacy(home, dir)
+	if err != nil || !migrated {
+		t.Fatalf("migrateLegacy() = %v, %v; want true, nil", migrated, err)
+	}
+
+	for _, name := range []string{"config.yaml", "env", "token", DBName, DBName + "-wal"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("%s was not carried over: %v", name, err)
+		}
+	}
+	// A stale leader discovery file would point the new binary at a dead port,
+	// and the log and eval artifacts are large and regenerable.
+	for _, name := range []string{"router.json", "router.log", "evals"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s should not have been carried over", name)
+		}
+	}
+	// Key material must not be widened by the copy.
+	info, err := os.Stat(filepath.Join(dir, "env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("env mode = %v, want 0600", info.Mode().Perm())
+	}
+	// The original install stays usable.
+	if b, err := os.ReadFile(filepath.Join(legacy, "config.yaml")); err != nil || string(b) != "version: 1\n" {
+		t.Errorf("legacy config.yaml altered: %q, %v", b, err)
+	}
+}
+
+// Running again must be a no-op rather than overwriting live state with a
+// stale copy of the pre-rename directory.
+func TestMigrateLegacyIsOnceOnly(t *testing.T) {
+	home := t.TempDir()
+	legacy := filepath.Join(home, LegacyDirName)
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.yaml"), []byte("old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, DirName)
+	if _, err := migrateLegacy(home, dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("new\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	migrated, err := migrateLegacy(home, dir)
+	if err != nil || migrated {
+		t.Fatalf("second migrateLegacy() = %v, %v; want false, nil", migrated, err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dir, "config.yaml")); string(b) != "new\n" {
+		t.Errorf("live config was overwritten: %q", b)
+	}
+}
+
+func TestMigrateLegacyNoopWithoutLegacyDir(t *testing.T) {
+	home := t.TempDir()
+	migrated, err := migrateLegacy(home, filepath.Join(home, DirName))
+	if err != nil || migrated {
+		t.Fatalf("migrateLegacy() = %v, %v; want false, nil", migrated, err)
+	}
+}
+
+// If the copy could not happen, reads still have to find an existing install
+// rather than silently falling back to defaults.
+func TestReadPathFallsBackToLegacy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	legacy := filepath.Join(home, LegacyDirName)
+	if err := os.MkdirAll(legacy, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "config.yaml"), []byte("version: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(legacy, "config.yaml")
+	if got := readPath(filepath.Join(home, DirName, "config.yaml")); got != want {
+		t.Errorf("readPath() = %q, want %q", got, want)
+	}
+
+	// Once the new file exists it wins, so the tool converges on the new dir.
+	newPath := filepath.Join(home, DirName, "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(newPath, []byte("version: 1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readPath(newPath); got != newPath {
+		t.Errorf("readPath() = %q, want %q", got, newPath)
+	}
+}
+
+func TestGetenvPrefersCurrentPrefix(t *testing.T) {
+	t.Setenv("AGENTIC_SESSION_ID", "old")
+	if got := Getenv("SESSION_ID"); got != "old" {
+		t.Errorf("Getenv with only legacy set = %q, want %q", got, "old")
+	}
+	t.Setenv("GREMLORD_SESSION_ID", "new")
+	if got := Getenv("SESSION_ID"); got != "new" {
+		t.Errorf("Getenv with both set = %q, want %q", got, "new")
+	}
+}

--- a/internal/eval/docker.go
+++ b/internal/eval/docker.go
@@ -20,6 +20,9 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 // ClaudeCodeContainerVersion pins the official Linux x64 Claude Code native
@@ -108,7 +111,14 @@ func containerEnvArgs(e DockerContainerEnv) []string {
 		"USER=nonroot",
 		"ANTHROPIC_BASE_URL=" + e.BaseURL,
 		"ANTHROPIC_AUTH_TOKEN=" + e.Token,
-		"ANTHROPIC_CUSTOM_HEADERS=X-Agentic-Session: " + e.SessionID + "\nX-Agentic-Profile: " + e.Profile + "\nX-Agentic-Pin-Model: " + e.Model,
+		"ANTHROPIC_CUSTOM_HEADERS=" + wire.HeaderSession + ": " + e.SessionID +
+			"\n" + wire.HeaderProfile + ": " + e.Profile +
+			"\n" + wire.HeaderPinModel + ": " + e.Model +
+			"\n" + wire.LegacyHeaderSession + ": " + e.SessionID +
+			"\n" + wire.LegacyHeaderProfile + ": " + e.Profile +
+			"\n" + wire.LegacyHeaderPinModel + ": " + e.Model,
+		config.EnvName("SESSION_ID") + "=" + e.SessionID,
+		config.EnvName("PROFILE") + "=" + e.Profile,
 		"AGENTIC_SESSION_ID=" + e.SessionID,
 		"AGENTIC_PROFILE=" + e.Profile,
 		// Pin all tier fallbacks to the candidate model so subagent spawns don't escape
@@ -513,11 +523,11 @@ func (r *Runner) runSWEBenchCandidate(ctx context.Context, manifest *Manifest, t
 	}
 	gradeStart := time.Now()
 	grade, err := RunSWEBench(ctx, r.Options.SWEBench, []SWEBenchPrediction{{
-		InstanceID: task.ID, ModelNameOrPath: fmt.Sprintf("agentic/%s/%s", label, model), ModelPatch: res.Patch,
+		InstanceID: task.ID, ModelNameOrPath: fmt.Sprintf("gremlord/%s/%s", label, model), ModelPatch: res.Patch,
 	}}, SWEBenchOptions{
 		Dataset: manifest.Dataset.Source, Split: datasetSplit(manifest),
-		RunID:     fmt.Sprintf("agentic-%d-%s-%03d-%s", r.Options.Seed, task.ID, attempt, label),
-		ModelName: fmt.Sprintf("agentic/%s/%s", label, model), InstanceIDs: []string{task.ID},
+		RunID:     fmt.Sprintf("gremlord-%d-%s-%03d-%s", r.Options.Seed, task.ID, attempt, label),
+		ModelName: fmt.Sprintf("gremlord/%s/%s", label, model), InstanceIDs: []string{task.ID},
 		// Keep the official instance image between the two paired arms. With
 		// clean=true the first arm's grader removes it, making the second arm
 		// attempt an impossible registry pull for a locally-built image.

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -21,7 +21,10 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 const SchemaVersion = 1
@@ -249,7 +252,7 @@ type Options struct {
 	Token     string
 	Profile   string
 	ClaudeBin string
-	// DataDir is ~/.agentic; the run reads back usage and routing telemetry
+	// DataDir is ~/.gremlord; the run reads back usage and routing telemetry
 	// from its SQLite database to attribute cost per candidate.
 	DataDir string
 	// Docker configures the SWE-bench Docker candidate lifecycle. Only
@@ -328,9 +331,9 @@ type VerifierResult struct {
 }
 
 // SWEBenchVerdict is the subset of the official per-instance report
-// (swebench.harness.grading.get_eval_report) agentic surfaces. FAIL_TO_PASS
+// (swebench.harness.grading.get_eval_report) gremlord surfaces. FAIL_TO_PASS
 // and PASS_TO_PASS pass/fail lists and the resolved verdict come directly
-// from the official grader; agentic does not recompute them.
+// from the official grader; gremlord does not recompute them.
 type SWEBenchVerdict struct {
 	Resolved      bool     `json:"resolved"`
 	PatchApplied  bool     `json:"patch_applied"`
@@ -424,7 +427,7 @@ func (r *Runner) Run(ctx context.Context, manifest *Manifest) (*Summary, error) 
 		r.Options.Timeout = 30 * time.Minute
 	}
 	if r.Options.OutputDir == "" {
-		r.Options.OutputDir = filepath.Join(".agentic", "evals", manifest.Name)
+		r.Options.OutputDir = filepath.Join(".gremlord", "evals", manifest.Name)
 	}
 	if r.Options.ClaudeBin == "" {
 		r.Options.ClaudeBin = "claude"
@@ -688,7 +691,7 @@ func (r *Runner) telemetry(sessionID string) (Usage, []RouteStep) {
 	if r.Options.DataDir == "" {
 		return Usage{}, nil
 	}
-	path := filepath.Join(r.Options.DataDir, "agentic.db")
+	path := filepath.Join(r.Options.DataDir, config.DBName)
 	var usage Usage
 	var trace []RouteStep
 	for attempt := 0; attempt < telemetryAttempts; attempt++ {
@@ -920,7 +923,11 @@ func evalEnv(env []string, o Options, sid, model string) []string {
 	env = setEnv(env, "ANTHROPIC_BASE_URL", o.BaseURL)
 	env = setEnv(env, "ANTHROPIC_AUTH_TOKEN", o.Token)
 	env = unsetEnv(env, "ANTHROPIC_API_KEY")
-	env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS", fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s\nX-Agentic-Pin-Model: %s", sid, o.Profile, model))
+	env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS", fmt.Sprintf("%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s",
+		wire.HeaderSession, sid, wire.HeaderProfile, o.Profile, wire.HeaderPinModel, model,
+		wire.LegacyHeaderSession, sid, wire.LegacyHeaderProfile, o.Profile, wire.LegacyHeaderPinModel, model))
+	env = setEnv(env, config.EnvName("SESSION_ID"), sid)
+	env = setEnv(env, config.EnvName("PROFILE"), o.Profile)
 	env = setEnv(env, "AGENTIC_SESSION_ID", sid)
 	env = setEnv(env, "AGENTIC_PROFILE", o.Profile)
 	// Pin all tier fallbacks to the candidate model so subagent spawns don't

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 func TestLoadManifestStrictAndValidates(t *testing.T) {

--- a/internal/eval/relay.go
+++ b/internal/eval/relay.go
@@ -16,7 +16,7 @@ import (
 
 const containerRelayHost = "host.docker.internal"
 
-// Relay is a temporary authenticated reverse proxy to an agentic router.
+// Relay is a temporary authenticated reverse proxy to a gremlord router.
 // URL is suitable for processes on the host; ContainerURL addresses the same
 // listener from Docker Desktop containers.
 type Relay struct {

--- a/internal/eval/swebench.go
+++ b/internal/eval/swebench.go
@@ -63,7 +63,7 @@ func (e SWEBenchEnv) validate() error {
 
 // MaterializeSWEBenchBridge writes the embedded pinned bridge to outputDir
 // and returns an environment ready for Check/Resolve/Grade calls. Keeping the
-// bridge embedded makes a released single-file agentic binary self-contained;
+// bridge embedded makes a released single-file gremlord binary self-contained;
 // users only need Python + `swebench==4.1.0` + Docker, not the source tree.
 func MaterializeSWEBenchBridge(outputDir, python string) (SWEBenchEnv, error) {
 	if outputDir == "" {
@@ -434,7 +434,7 @@ func runSWEBenchBridgeDir(ctx context.Context, env SWEBenchEnv, args []string, d
 	cleanup := func() {}
 	if dir == "" {
 		var err error
-		dir, err = os.MkdirTemp("", "agentic-swebench-")
+		dir, err = os.MkdirTemp("", "gremlord-swebench-")
 		if err != nil {
 			return err
 		}

--- a/internal/eval/swebench_bridge.py
+++ b/internal/eval/swebench_bridge.py
@@ -2,9 +2,9 @@
 """Pinned bridge to SWE-bench's official v4.1.0 evaluation harness.
 
 This process owns no benchmark semantics of its own: it validates the
-installed swebench package matches the version agentic was built against,
+installed swebench package matches the version gremlord was built against,
 then delegates to the official APIs for everything that matters (dataset
-loading, test spec / image derivation, and grading). agentic's Go code only
+loading, test spec / image derivation, and grading). gremlord's Go code only
 ever sees the JSON this bridge prints on stdout.
 
 Four operations, selected by --op:

--- a/internal/eval/swebench_test.go
+++ b/internal/eval/swebench_test.go
@@ -38,10 +38,10 @@ func TestWriteSWEBenchPredictionsOfficialSchema(t *testing.T) {
 		{InstanceID: "django__django-11001", ModelPatch: "diff --git a/a b/a\n"},
 		{InstanceID: "sympy__sympy-20590", ModelNameOrPath: "other", ModelPatch: "patch"},
 	}
-	if err := validateSWEBenchPredictions(predictions, "agentic/auto"); err != nil {
+	if err := validateSWEBenchPredictions(predictions, "gremlord/auto"); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeSWEBenchPredictions(path, predictions, "agentic/auto"); err != nil {
+	if err := writeSWEBenchPredictions(path, predictions, "gremlord/auto"); err != nil {
 		t.Fatal(err)
 	}
 	f, err := os.Open(path)
@@ -61,7 +61,7 @@ func TestWriteSWEBenchPredictionsOfficialSchema(t *testing.T) {
 	if err := s.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 2 || got[0].ModelNameOrPath != "agentic/auto" || got[1].ModelNameOrPath != "other" || got[0].ModelPatch != predictions[0].ModelPatch {
+	if len(got) != 2 || got[0].ModelNameOrPath != "gremlord/auto" || got[1].ModelNameOrPath != "other" || got[0].ModelPatch != predictions[0].ModelPatch {
 		t.Fatalf("predictions = %#v", got)
 	}
 }

--- a/internal/launch/agentsync.go
+++ b/internal/launch/agentsync.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/maorbril/agentic/internal/agents"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/agents"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // noticeAgentDrift prints a one-shot, NON-BLOCKING notice when the generated
-// per-alias subagents have drifted from config, pointing at `agentic agents
+// per-alias subagents have drifted from config, pointing at `gremlord agents
 // sync`. It deliberately does not read stdin: this runs immediately before
 // the interactive claude child takes over the terminal, and the tty may be
 // in raw mode (Enter arrives as \r, not \n) — a cooked line read would hang
 // forever. Quiet when in sync, when not on a terminal, when opted out, or
 // when the user already dismissed this exact config state.
 func noticeAgentDrift(cfg *config.Config, dataDir string) {
-	if os.Getenv("AGENTIC_NO_AGENT_SYNC") != "" {
+	if config.Getenv("NO_AGENT_SYNC") != "" {
 		return
 	}
 	if !isTerminal(os.Stderr) {
@@ -35,9 +35,9 @@ func noticeAgentDrift(cfg *config.Config, dataDir string) {
 		return // already shown for this exact config state
 	}
 
-	fmt.Fprintf(os.Stderr, "\nagentic: %s — run `agentic agents sync` to make them selectable (e.g. subagent_type: %q).\n",
+	fmt.Fprintf(os.Stderr, "\ngremlord: %s — run `gremlord agents sync` to make them selectable (e.g. subagent_type: %q).\n",
 		summarize(changes), firstName(changes))
-	fmt.Fprintln(os.Stderr, "  (won't mention again until your model aliases change; AGENTIC_NO_AGENT_SYNC=1 to silence)")
+	fmt.Fprintln(os.Stderr, "  (won't mention again until your model aliases change; GREMLORD_NO_AGENT_SYNC=1 to silence)")
 
 	// Record now so the notice is one-shot per config state — we're not
 	// waiting for an answer, so "shown" is the only signal we have.

--- a/internal/launch/launch.go
+++ b/internal/launch/launch.go
@@ -16,9 +16,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/router"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/router"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 type Options struct {
@@ -62,7 +63,7 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 	if profName != "" {
 		p, ok := cfg.Profiles[profName]
 		if !ok {
-			return fmt.Errorf("profile %q not found in ~/.agentic/config.yaml", profName)
+			return fmt.Errorf("profile %q not found in ~/.gremlord/config.yaml", profName)
 		}
 		prof = p
 	}
@@ -71,7 +72,7 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 	sessionID := newSessionID()
 
 	if prof.Passthrough || opts.Passthrough {
-		fmt.Fprintf(os.Stderr, "agentic: passthrough profile — subscription billing, cost tracking unavailable\n")
+		fmt.Fprintf(os.Stderr, "gremlord: passthrough profile — subscription billing, cost tracking unavailable\n")
 	} else {
 		token, err := Token(dataDir)
 		if err != nil {
@@ -92,7 +93,7 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 		model := prof.Model
 		if opts.ModelFlag != "" {
 			if cfg.IsCLIAlias(opts.ModelFlag) {
-				return fmt.Errorf("cli alias %q is only available as an explicit subagent (agentic-%s), not a session model", opts.ModelFlag, opts.ModelFlag)
+				return fmt.Errorf("cli alias %q is only available as an explicit subagent (gremlord-%s), not a session model", opts.ModelFlag, opts.ModelFlag)
 			}
 			model = opts.ModelFlag
 		}
@@ -107,7 +108,7 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 
 		// Notice (non-blocking) when the per-alias subagents have drifted from
 		// config. Router-backed sessions only — a passthrough profile doesn't
-		// resolve agentic aliases, so the generated agents wouldn't work there.
+		// resolve gremlord aliases, so the generated agents wouldn't work there.
 		noticeAgentDrift(cfg, dataDir)
 	}
 
@@ -137,10 +138,10 @@ func Run(ctx context.Context, cfg *config.Config, dataDir string, opts Options, 
 }
 
 // sessionEnv assembles the child process environment for a non-passthrough
-// profile: router creds, model selection, and the X-Agentic-* headers Claude
+// profile: router creds, model selection, and the X-Gremlord-* headers Claude
 // Code carries transparently on every request so the router can attribute
 // spend to this session and (when pinned) enforce the pin. cwd rides along as
-// X-Agentic-Cwd so cli-delegation backends run the peer CLI in the session's
+// X-Gremlord-Cwd so cli-delegation backends run the peer CLI in the session's
 // directory (the router leader is a shared long-lived process whose own cwd
 // is meaningless). Extracted from Run so PinTiers behavior is directly
 // testable without spawning a router or a claude process.
@@ -156,7 +157,8 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 	cwd = strings.NewReplacer("\n", "", "\r", "").Replace(cwd)
 	cwdHeader := ""
 	if cwd != "" {
-		cwdHeader = "\nX-Agentic-Cwd: " + cwd
+		cwdHeader = "\n" + wire.HeaderCwd + ": " + cwd +
+			"\n" + wire.LegacyHeaderCwd + ": " + cwd
 	}
 	if prof.PinTiers && model != "" {
 		// Pin every tier fallback — including Claude Code's own subagent
@@ -170,7 +172,7 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 		env = setEnv(env, "ANTHROPIC_DEFAULT_HAIKU_MODEL", model)
 		env = setEnv(env, "CLAUDE_CODE_SUBAGENT_MODEL", model)
 		env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS",
-			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s\nX-Agentic-Pin-Model: %s%s", sessionID, profName, model, cwdHeader))
+			sessionHeaders(sessionID, profName, model, cwdHeader))
 	} else {
 		if prof.SmallFast != "" {
 			env = setEnv(env, "ANTHROPIC_SMALL_FAST_MODEL", prof.SmallFast)
@@ -179,8 +181,12 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 			env = setEnv(env, "ANTHROPIC_DEFAULT_"+strings.ToUpper(tier)+"_MODEL", alias)
 		}
 		env = setEnv(env, "ANTHROPIC_CUSTOM_HEADERS",
-			fmt.Sprintf("X-Agentic-Session: %s\nX-Agentic-Profile: %s%s", sessionID, profName, cwdHeader))
+			sessionHeaders(sessionID, profName, "", cwdHeader))
 	}
+	// Both spellings for one release: a ~/.claude/settings.json statusLine
+	// still pointing at the old agentic executable reads only AGENTIC_*.
+	env = setEnv(env, config.EnvName("SESSION_ID"), sessionID)
+	env = setEnv(env, config.EnvName("PROFILE"), profName)
 	env = setEnv(env, "AGENTIC_SESSION_ID", sessionID)
 	env = setEnv(env, "AGENTIC_PROFILE", profName)
 	env = enableToolSearch(env, prof)
@@ -190,8 +196,8 @@ func sessionEnv(env []string, baseURL, token, sessionID, profName string, prof c
 	return env
 }
 
-// autoApprovedTools is the tool allowlist every agentic session runs with.
-// It is the set `clauder wrap --slave` used to pass before agentic spawned
+// autoApprovedTools is the tool allowlist every gremlord session runs with.
+// It is the set `clauder wrap --slave` used to pass before gremlord spawned
 // claude itself, kept identical so the launch path change is invisible.
 // Allowlisting mcp__clauder__* is inert when clauder is not installed.
 var autoApprovedTools = []string{
@@ -221,7 +227,7 @@ func buildChild(opts Options) []string {
 }
 
 func recordSession(dataDir, id, profile string, start bool) {
-	st, err := store.Open(filepath.Join(dataDir, "agentic.db"))
+	st, err := store.Open(filepath.Join(dataDir, config.DBName))
 	if err != nil {
 		return
 	}
@@ -235,7 +241,7 @@ func recordSession(dataDir, id, profile string, start bool) {
 }
 
 func printSummary(dataDir string, cfg *config.Config, sessionID, profile string) {
-	st, err := store.OpenReadOnly(filepath.Join(dataDir, "agentic.db"))
+	st, err := store.OpenReadOnly(filepath.Join(dataDir, config.DBName))
 	if err != nil {
 		return
 	}
@@ -243,7 +249,7 @@ func printSummary(dataDir string, cfg *config.Config, sessionID, profile string)
 	dayStart := time.Now().Truncate(24 * time.Hour)
 	sess, _ := st.TotalSince(time.Time{}, "", sessionID)
 	day, _ := st.TotalSince(dayStart, "", "")
-	line := fmt.Sprintf("agentic: session cost $%.2f (profile: %s) — today $%.2f", sess, profile, day)
+	line := fmt.Sprintf("gremlord: session cost $%.2f (profile: %s) — today $%.2f", sess, profile, day)
 	if cfg.Budgets != nil && cfg.Budgets.Daily > 0 {
 		line += fmt.Sprintf(" / $%.2f daily budget", cfg.Budgets.Daily)
 	}
@@ -303,4 +309,28 @@ func unsetEnv(env []string, key string) []string {
 		}
 	}
 	return out
+}
+
+// sessionHeaders builds the ANTHROPIC_CUSTOM_HEADERS value carrying session
+// identity to the router. Both header spellings go out for one release: the
+// router is whichever binary won the port, so a new launcher may be talking to
+// an agentic router that only reads X-Agentic-*. Dropping the old spelling
+// there would lose spend attribution silently.
+func sessionHeaders(sessionID, profName, pinModel, cwdHeader string) string {
+	pairs := [][2]string{
+		{wire.HeaderSession, sessionID},
+		{wire.LegacyHeaderSession, sessionID},
+		{wire.HeaderProfile, profName},
+		{wire.LegacyHeaderProfile, profName},
+	}
+	if pinModel != "" {
+		pairs = append(pairs,
+			[2]string{wire.HeaderPinModel, pinModel},
+			[2]string{wire.LegacyHeaderPinModel, pinModel})
+	}
+	lines := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		lines = append(lines, p[0]+": "+p[1])
+	}
+	return strings.Join(lines, "\n") + cwdHeader
 }

--- a/internal/launch/launch_test.go
+++ b/internal/launch/launch_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // envVal returns the value of key in env, or "" if unset.

--- a/internal/peers/guidance.go
+++ b/internal/peers/guidance.go
@@ -8,13 +8,18 @@ import (
 )
 
 const (
-	guidanceStart = "<!-- agentic:peers:start -->"
-	guidanceEnd   = "<!-- agentic:peers:end -->"
+	guidanceStart = "<!-- gremlord:peers:start -->"
+	guidanceEnd   = "<!-- gremlord:peers:end -->"
+
+	// Pre-rename markers. Found and replaced in place, so the rename does not
+	// strand an orphaned block that duplicates the guidance.
+	legacyStart = "<!-- agentic:peers:start -->"
+	legacyEnd   = "<!-- agentic:peers:end -->"
 )
 
 // Guidance tells a session how to turn an approximate name into a specific
 // peer. It lands in ~/.claude/CLAUDE.md so plain `claude` sessions get it too,
-// not just agentic-launched ones.
+// not just gremlord-launched ones.
 const Guidance = `## Talking to other Claude sessions
 
 When asked to work with another session by an approximate name — "work with
@@ -23,7 +28,7 @@ rather than asking which session was meant. Session names are auto-derived from
 whatever that session is doing, so the name a user says is usually the project
 directory, and ListAgents does not show directories.
 
-1. Run ` + "`agentic peers <approximate name>`" + ` — it matches on both session name and
+1. Run ` + "`gremlord peers <approximate name>`" + ` — it matches on both session name and
    working directory, and lists only sessions that can actually receive a
    message.
 2. Call ListAgents to get the ` + "`[ref]`" + ` for the name it returned.
@@ -62,19 +67,28 @@ func InstallGuidance(path string) (Action, error) {
 	}
 
 	text := string(existing)
-	start := strings.Index(text, guidanceStart)
+	startMarker, endMarker := guidanceStart, guidanceEnd
+	start := strings.Index(text, startMarker)
 	if start < 0 {
-		if strings.Contains(text, guidanceEnd) {
-			return Unchanged, fmt.Errorf("%s has a stray %s marker — remove it and re-run", path, guidanceEnd)
+		// Fall back to the pre-rename markers so an agentic-era block is
+		// rewritten where it stands instead of being left behind alongside a
+		// second, near-identical block.
+		if i := strings.Index(text, legacyStart); i >= 0 {
+			startMarker, endMarker, start = legacyStart, legacyEnd, i
+		}
+	}
+	if start < 0 {
+		if strings.Contains(text, endMarker) {
+			return Unchanged, fmt.Errorf("%s has a stray %s marker — remove it and re-run", path, endMarker)
 		}
 		return Updated, os.WriteFile(path, []byte(strings.TrimRight(text, "\n")+"\n\n"+block+"\n"), 0o644)
 	}
 
-	end := strings.Index(text[start:], guidanceEnd)
+	end := strings.Index(text[start:], endMarker)
 	if end < 0 {
-		return Unchanged, fmt.Errorf("%s has an unterminated agentic block — restore its %s marker and re-run", path, guidanceEnd)
+		return Unchanged, fmt.Errorf("%s has an unterminated gremlord block — restore its %s marker and re-run", path, endMarker)
 	}
-	end += start + len(guidanceEnd)
+	end += start + len(endMarker)
 
 	if text[start:end] == block {
 		return Unchanged, nil

--- a/internal/pricing/prices.json
+++ b/internal/pricing/prices.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "USD per million tokens, keyed by upstream model ID. Anthropic prices cached 2026-07-17. Non-Anthropic models: add here via `agentic models update-prices`, or set `pricing:` in ~/.agentic/config.yaml. cache_read ~= 0.1x input; cache_write ~= 1.25x input (5m TTL).",
+  "_comment": "USD per million tokens, keyed by upstream model ID. Anthropic prices cached 2026-07-17. Non-Anthropic models: add here via `gremlord models update-prices`, or set `pricing:` in ~/.gremlord/config.yaml. cache_read ~= 0.1x input; cache_write ~= 1.25x input (5m TTL).",
   "claude-fable-5":    {"input": 10.0, "output": 50.0, "cache_read": 1.0,  "cache_write": 12.5},
   "claude-opus-4-8":   {"input": 5.0,  "output": 25.0, "cache_read": 0.5,  "cache_write": 6.25},
   "claude-opus-4-7":   {"input": 5.0,  "output": 25.0, "cache_read": 0.5,  "cache_write": 6.25},

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 //go:embed prices.json
 var embedded []byte
 
 // Table maps upstream model ID -> price. Merge order (later wins):
-// embedded -> ~/.agentic/prices.json -> config `pricing:` -> per-model override.
+// embedded -> ~/.gremlord/prices.json -> config `pricing:` -> per-model override.
 type Table struct {
 	prices map[string]config.Price
 }

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -3,7 +3,7 @@ package pricing
 import (
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func TestEmbeddedPrices(t *testing.T) {

--- a/internal/router/autogoal.go
+++ b/internal/router/autogoal.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // goalRouter runs a second, independent classification pass over each new
@@ -114,7 +114,7 @@ func (s *Server) classifyGoalViaBackend(ctx context.Context, rule config.RouteRu
 // judged goal-worthy, naming the harness's own recognized mechanisms so the
 // model can act on it directly rather than being told to invent one.
 const goalReminderTemplate = `<system-reminder>
-agentic: this task looks well suited to a recurring goal loop rather than a
+gremlord: this task looks well suited to a recurring goal loop rather than a
 single reply (%s). If a persistent loop would help — checking back on
 progress, retrying until a condition holds, babysitting a long-running
 process — call ScheduleWakeup with prompt "<<autonomous-loop-dynamic>>" and a

--- a/internal/router/autogoal_test.go
+++ b/internal/router/autogoal_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func newGoal(d goalDecision, err error) *goalRouter {

--- a/internal/router/autoroute.go
+++ b/internal/router/autoroute.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // autoRouter implements dynamic tier routing: a cheap classifier model

--- a/internal/router/autoroute_test.go
+++ b/internal/router/autoroute_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func testRule() config.RouteRule {

--- a/internal/router/calibration.go
+++ b/internal/router/calibration.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 const (

--- a/internal/router/calibration_e2e_test.go
+++ b/internal/router/calibration_e2e_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // calibServer serves one model with a deliberately tight window, over a

--- a/internal/router/configwatch.go
+++ b/internal/router/configwatch.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // watchConfig polls the config file's mtime and reloads the server when it
-// changes. This closes the gap for direct edits to ~/.agentic/config.yaml:
-// `agentic config set` already hot-reloads via POST /agentic/reload, but an
+// changes. This closes the gap for direct edits to ~/.gremlord/config.yaml:
+// `gremlord config set` already hot-reloads via the reload path, but an
 // editor save does not, so the running leader would serve a stale config
 // until restarted.
 //

--- a/internal/router/ctxscale_eval_test.go
+++ b/internal/router/ctxscale_eval_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // compactAt is the simulated auto-compact trigger, as a fraction of the

--- a/internal/router/gauge.go
+++ b/internal/router/gauge.go
@@ -1,8 +1,8 @@
 package router
 
 import (
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // gaugeBudget resolves the one context budget a dynamically-routed

--- a/internal/router/gauge_e2e_test.go
+++ b/internal/router/gauge_e2e_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 // gaugeServer stands up a rule with a 1M "deep" tier and a 100K "light"

--- a/internal/router/gauge_test.go
+++ b/internal/router/gauge_test.go
@@ -3,8 +3,8 @@ package router
 import (
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 func gaugeCfg(t *testing.T) *config.Config {

--- a/internal/router/leader.go
+++ b/internal/router/leader.go
@@ -13,14 +13,16 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 // Version is stamped at build time via -ldflags.
 var Version = "dev"
 
-// Discovery is written to ~/.agentic/router.json by the current leader.
+// Discovery is written to ~/.gremlord/router.json by the current leader.
 type Discovery struct {
 	PID       int    `json:"pid"`
 	Port      int    `json:"port"`
@@ -42,7 +44,7 @@ type Manager struct {
 func (m *Manager) BaseURL() string { return fmt.Sprintf("http://127.0.0.1:%d", m.Port) }
 
 // Run maintains leadership until ctx is canceled. It first tries to become
-// leader; if the port is held by a healthy agentic router it follows and
+// leader; if the port is held by a healthy gremlord router it follows and
 // watches, racing to re-bind whenever the leader disappears.
 func (m *Manager) Run(ctx context.Context) error {
 	for {
@@ -56,11 +58,11 @@ func (m *Manager) Run(ctx context.Context) error {
 			return nil
 		case errors.Is(err, syscall.EADDRINUSE):
 			if !m.healthy(ctx) {
-				// Port held by a non-agentic process, or a wedged leader.
+				// Port held by a foreign process, or a wedged leader.
 				m.Log.Warn("router port busy but not healthy; retrying", "port", m.Port)
 			}
 		default:
-			return fmt.Errorf("router: cannot bind 127.0.0.1:%d: %w (set router.port in ~/.agentic/config.yaml)", m.Port, err)
+			return fmt.Errorf("router: cannot bind 127.0.0.1:%d: %w (set router.port in ~/.gremlord/config.yaml)", m.Port, err)
 		}
 		select {
 		case <-ctx.Done():
@@ -94,16 +96,24 @@ func (m *Manager) tryBind() (net.Listener, error) {
 func (m *Manager) healthy(ctx context.Context) bool {
 	reqCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, m.BaseURL()+"/agentic/health", nil)
-	if err != nil {
-		return false
+	// Probe both spellings: the port may be held by a pre-rename agentic
+	// router, which serves only the legacy path. Reading a healthy peer as a
+	// foreign process would make this instance refuse to start.
+	for _, path := range []string{wire.PathHealth, wire.LegacyPathHealth} {
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, m.BaseURL()+path, nil)
+		if err != nil {
+			continue
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+		if resp.StatusCode == http.StatusOK {
+			return true
+		}
 	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	return false
 }
 
 func (m *Manager) lead(ctx context.Context, ln net.Listener) error {
@@ -115,7 +125,7 @@ func (m *Manager) lead(ctx context.Context, ln net.Listener) error {
 		ln.Close()
 		return err
 	}
-	st, err := store.Open(filepath.Join(m.DataDir, "agentic.db"))
+	st, err := store.Open(filepath.Join(m.DataDir, config.DBName))
 	if err != nil {
 		ln.Close()
 		return err
@@ -125,7 +135,7 @@ func (m *Manager) lead(ctx context.Context, ln net.Listener) error {
 	srv := NewServer(cfg, m.Token, m.DataDir, st, m.Log)
 	httpSrv := &http.Server{Handler: srv.Handler()}
 
-	// Hot-reload on direct edits to ~/.agentic/config.yaml.
+	// Hot-reload on direct edits to ~/.gremlord/config.yaml.
 	go watchConfig(ctx, srv, m.Log)
 
 	m.writeDiscovery()

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -13,16 +13,17 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/backend/anthropicbe"
-	"github.com/maorbril/agentic/internal/backend/clibe"
-	"github.com/maorbril/agentic/internal/backend/openaibe"
-	"github.com/maorbril/agentic/internal/budget"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/pricing"
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/backend/anthropicbe"
+	"github.com/gremlord/gremlord/internal/backend/clibe"
+	"github.com/gremlord/gremlord/internal/backend/openaibe"
+	"github.com/gremlord/gremlord/internal/budget"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/pricing"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 type Server struct {
@@ -55,7 +56,7 @@ func NewServer(cfg *config.Config, token, dataDir string, st *store.Store, logge
 	return s
 }
 
-// Reload re-reads the config file; called by /agentic/reload so config CLI
+// Reload re-reads the config file; called by the reload path so config CLI
 // edits apply to live sessions without restart.
 func (s *Server) Reload() error {
 	cfg, err := config.Load()
@@ -74,8 +75,11 @@ func (s *Server) Reload() error {
 
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /agentic/health", s.handleHealth)
-	mux.HandleFunc("POST /agentic/reload", s.auth(s.handleReload))
+	mux.HandleFunc("GET "+wire.PathHealth, s.handleHealth)
+	mux.HandleFunc("POST "+wire.PathReload, s.auth(s.handleReload))
+	// Pre-rename paths, so an gremlord CLI can still reach this router.
+	mux.HandleFunc("GET "+wire.LegacyPathHealth, s.handleHealth)
+	mux.HandleFunc("POST "+wire.LegacyPathReload, s.auth(s.handleReload))
 	mux.HandleFunc("POST /v1/messages", s.auth(s.handleMessages(false)))
 	mux.HandleFunc("POST /v1/messages/count_tokens", s.auth(s.handleMessages(true)))
 	// Catch-all: unknown /v1/* endpoints go to the default anthropic
@@ -105,7 +109,7 @@ func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
 			anthropic.WriteError(w, 401, "authentication_error",
-				"agentic router: invalid local token (launch sessions via `agentic`)")
+				"gremlord router: invalid local token (launch sessions via `gremlord`)")
 			return
 		}
 		next(w, r)
@@ -117,24 +121,24 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 		start := time.Now()
 		raw, err := io.ReadAll(r.Body)
 		if err != nil {
-			anthropic.WriteError(w, 400, "invalid_request_error", "agentic: reading body: "+err.Error())
+			anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: reading body: "+err.Error())
 			return
 		}
 		env, err := anthropic.ParseEnvelope(raw)
 		if err != nil || env.Model == "" {
-			anthropic.WriteError(w, 400, "invalid_request_error", "agentic: request body is not a Messages API request")
+			anthropic.WriteError(w, 400, "invalid_request_error", "gremlord: request body is not a Messages API request")
 			return
 		}
 		cfg := s.cfg.Load()
 		calib := s.calib.get()
-		sessionID := r.Header.Get("X-Agentic-Session")
+		sessionID := wire.Session(r.Header)
 		// gauge is the budget this session's client-facing token counts
 		// are scaled against — one budget per routing rule, so the
 		// context gauge does not change meaning when the tier does. 0
 		// for a directly-addressed alias or a pinned session: those
 		// scale against the model they name.
 		gauge := 0
-		pinModel := r.Header.Get("X-Agentic-Pin-Model")
+		pinModel := wire.PinModel(r.Header)
 		resolveAlias := env.Model
 		if pinModel != "" {
 			// A pinned session (eval candidates, pin_tiers profiles) must
@@ -177,7 +181,7 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 		}
 		route, err := cfg.Resolve(resolveAlias)
 		if err != nil {
-			anthropic.WriteError(w, 404, "not_found_error", "agentic: "+err.Error()+" (see ~/.agentic/config.yaml)")
+			anthropic.WriteError(w, 404, "not_found_error", "gremlord: "+err.Error()+" (see ~/.gremlord/config.yaml)")
 			return
 		}
 
@@ -191,7 +195,7 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 			if req, perr := anthropic.ParseRequest(raw); perr == nil {
 				comp = tokens.Compose(req)
 				if overflow, required, budget := promptTooLong(route, req, calib); overflow {
-					msg := fmt.Sprintf("agentic: request too large for model %q context budget "+
+					msg := fmt.Sprintf("gremlord: request too large for model %q context budget "+
 						"(estimated %d + reserved output exceeds budget %d); "+
 						"reduce the conversation or switch models",
 						route.Model.ID, required, budget)
@@ -206,7 +210,7 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 			// oversized bodies — common with accumulated images/attachments —
 			// before dispatch, instead of a mangled upstream 413 retry loop.
 			if tooLarge, size, cap := bodyTooLarge(route, int64(len(raw))); tooLarge {
-				msg := fmt.Sprintf("agentic: request body too large for provider %q "+
+				msg := fmt.Sprintf("gremlord: request body too large for provider %q "+
 					"(%d bytes exceeds max_request_bytes %d); "+
 					"run /compact or remove images/attachments",
 					route.ProviderName, size, cap)
@@ -218,10 +222,10 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 			}
 		}
 
-		profile := r.Header.Get("X-Agentic-Profile")
+		profile := wire.Profile(r.Header)
 		if !countTokens && route.Provider.Type != config.ProviderCLI {
 			// CLI delegation spends against the peer CLI's subscription, outside
-			// agentic's pricing data. A $0 API budget must not block capacity it
+			// gremlord's pricing data. A $0 API budget must not block capacity it
 			// neither meters nor pays for.
 			if msg := s.gate.Check(profile); msg != "" {
 				// 400 deliberately — 429/5xx would make Claude Code retry-spin;
@@ -246,7 +250,7 @@ func (s *Server) handleMessages(countTokens bool) http.HandlerFunc {
 			be = s.cli
 		default:
 			anthropic.WriteError(w, 501, "api_error",
-				fmt.Sprintf("agentic: provider type %q not implemented (model %q)", route.Provider.Type, env.Model))
+				fmt.Sprintf("gremlord: provider type %q not implemented (model %q)", route.Provider.Type, env.Model))
 			return
 		}
 		var res backend.Result
@@ -271,14 +275,14 @@ func (s *Server) recordUsage(r *http.Request, route config.Resolved, alias strin
 		u.InputTokens, u.OutputTokens, u.CacheReadInputTokens, u.CacheCreationInputTokens)
 	if route.Provider.Type == config.ProviderCLI {
 		// Even when the optional CLI model ID happens to match an entry in the
-		// API price table, subscription spend is opaque to agentic.
+		// API price table, subscription spend is opaque to gremlord.
 		cost, priced = 0, false
 	}
 	budget := route.Model.ContextBudget()
 	ev := store.UsageEvent{
 		TS:               time.Now(),
-		SessionID:        r.Header.Get("X-Agentic-Session"),
-		Profile:          r.Header.Get("X-Agentic-Profile"),
+		SessionID:        wire.Session(r.Header),
+		Profile:          wire.Profile(r.Header),
 		Provider:         route.ProviderName,
 		Model:            route.Model.ID,
 		Alias:            alias,
@@ -338,7 +342,7 @@ func (s *Server) handleCatchAll(w http.ResponseWriter, r *http.Request) {
 	cfg := s.cfg.Load()
 	p, ok := cfg.Providers[config.ProviderAnthropic]
 	if !ok {
-		anthropic.WriteError(w, 404, "not_found_error", "agentic: no anthropic provider configured for "+r.URL.Path)
+		anthropic.WriteError(w, 404, "not_found_error", "gremlord: no anthropic provider configured for "+r.URL.Path)
 		return
 	}
 	u := strings.TrimSuffix(p.BaseURL, "/") + r.URL.Path
@@ -347,7 +351,7 @@ func (s *Server) handleCatchAll(w http.ResponseWriter, r *http.Request) {
 	}
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, u, r.Body)
 	if err != nil {
-		anthropic.WriteError(w, 500, "api_error", "agentic: "+err.Error())
+		anthropic.WriteError(w, 500, "api_error", "gremlord: "+err.Error())
 		return
 	}
 	req.Header = r.Header.Clone()

--- a/internal/router/server_test.go
+++ b/internal/router/server_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/backend"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/backend"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 const testToken = "test-token"

--- a/internal/router/size.go
+++ b/internal/router/size.go
@@ -4,9 +4,9 @@ import (
 	"math"
 	"sort"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/tokens"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/tokens"
 )
 
 // defaultReservedOutput is the output headroom reserved when neither the

--- a/internal/router/size_e2e_test.go
+++ b/internal/router/size_e2e_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
-	"github.com/maorbril/agentic/internal/store"
+	"github.com/gremlord/gremlord/internal/config"
+	"github.com/gremlord/gremlord/internal/store"
 )
 
 // newSizedServer builds a router whose "tiny" model has a 1000-token budget,

--- a/internal/router/size_test.go
+++ b/internal/router/size_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func sizedCfg() *config.Config {

--- a/internal/router/tasks.go
+++ b/internal/router/tasks.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 // taskClassifierPrompt asks the classifier for tier and task together in one

--- a/internal/router/tasks_test.go
+++ b/internal/router/tasks_test.go
@@ -3,7 +3,7 @@ package router
 import (
 	"testing"
 
-	"github.com/maorbril/agentic/internal/config"
+	"github.com/gremlord/gremlord/internal/config"
 )
 
 func TestParseTaskLabel(t *testing.T) {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,4 +1,4 @@
-// Package selfupdate implements `agentic update` — fetching the latest
+// Package selfupdate implements `gremlord update` — fetching the latest
 // GitHub release and replacing the running binary with it.
 package selfupdate
 
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-const repo = "maorbril/agentic"
+const repo = "gremlord/gremlord"
 
 // Release is the subset of the GitHub releases API response we need.
 type Release struct {
@@ -63,7 +63,7 @@ func AssetName() (string, error) {
 	if runtime.GOOS == "windows" {
 		ext = ".exe"
 	}
-	return fmt.Sprintf("agentic-%s-%s%s", runtime.GOOS, runtime.GOARCH, ext), nil
+	return fmt.Sprintf("gremlord-%s-%s%s", runtime.GOOS, runtime.GOARCH, ext), nil
 }
 
 // Download fetches the named release's binary for the current OS/arch to
@@ -106,11 +106,11 @@ func Download(ctx context.Context, tag, destPath string) error {
 // Apply replaces the binary at exePath with the one at newPath. The current
 // binary is moved aside first rather than overwritten in place — both Unix
 // and Windows leave an already-running executable usable after it's been
-// renamed or unlinked, so this works even when exePath is agentic's own
+// renamed or unlinked, so this works even when exePath is gremlord's own
 // currently-executing binary.
 func Apply(exePath, newPath string) error {
 	dir := filepath.Dir(exePath)
-	oldPath := filepath.Join(dir, ".agentic.old")
+	oldPath := filepath.Join(dir, ".gremlord.old")
 	os.Remove(oldPath) // best effort, leftover from a previous update
 
 	if err := os.Rename(exePath, oldPath); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,7 @@ type Store struct {
 	db *sql.DB
 }
 
-// Open opens (creating if needed) the agentic database. modernc.org/sqlite
+// Open opens (creating if needed) the gremlord database. modernc.org/sqlite
 // uses _pragma=name(value) DSN syntax; WAL lets CLI readers run while the
 // router leader holds the single write connection.
 func Open(path string) (*Store, error) {

--- a/internal/tokens/estimate.go
+++ b/internal/tokens/estimate.go
@@ -12,7 +12,7 @@ package tokens
 import (
 	"unicode/utf8"
 
-	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/anthropic"
 )
 
 const (

--- a/internal/tokens/estimate_test.go
+++ b/internal/tokens/estimate_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/anthropic"
 )
 
 func req(t *testing.T, body string) *anthropic.MessagesRequest {

--- a/internal/tokens/scale.go
+++ b/internal/tokens/scale.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"math"
 
-	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/anthropic"
 )
 
 // AssumedWindow is the context window Claude Code believes it has. Claude

--- a/internal/tokens/scale_test.go
+++ b/internal/tokens/scale_test.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"testing"
 
-	"github.com/maorbril/agentic/internal/anthropic"
+	"github.com/gremlord/gremlord/internal/anthropic"
 )
 
 func TestScaleFactor(t *testing.T) {

--- a/internal/wire/headers.go
+++ b/internal/wire/headers.go
@@ -1,0 +1,63 @@
+// Package wire names the HTTP headers the launcher and the router use to
+// attribute a request to a session. Claude Code carries them transparently on
+// every request via ANTHROPIC_CUSTOM_HEADERS, so they are a protocol between
+// two gremlord processes rather than anything a user sets.
+package wire
+
+import "net/http"
+
+// Current header names.
+const (
+	HeaderSession  = "X-Gremlord-Session"
+	HeaderProfile  = "X-Gremlord-Profile"
+	HeaderPinModel = "X-Gremlord-Pin-Model"
+	HeaderCwd      = "X-Gremlord-Cwd"
+)
+
+// Pre-rename header names, still accepted on read and still written alongside
+// the new ones for one release.
+//
+// Both directions of a mixed install are reachable, because the router is
+// whichever binary won the port: a new gremlord launcher can be talking to an
+// gremlord router left running from before the upgrade, or the reverse. A
+// reader that understood only one spelling would silently drop session
+// attribution, which surfaces as spend that no session accounts for.
+const (
+	LegacyHeaderSession  = "X-Agentic-Session"
+	LegacyHeaderProfile  = "X-Agentic-Profile"
+	LegacyHeaderPinModel = "X-Agentic-Pin-Model"
+	LegacyHeaderCwd      = "X-Agentic-Cwd"
+)
+
+func first(h http.Header, name, legacy string) string {
+	if v := h.Get(name); v != "" {
+		return v
+	}
+	return h.Get(legacy)
+}
+
+// Session returns the launching session's id.
+func Session(h http.Header) string { return first(h, HeaderSession, LegacyHeaderSession) }
+
+// Profile returns the launching session's profile name.
+func Profile(h http.Header) string { return first(h, HeaderProfile, LegacyHeaderProfile) }
+
+// PinModel returns the model every tier is pinned to, or "" when unpinned.
+func PinModel(h http.Header) string { return first(h, HeaderPinModel, LegacyHeaderPinModel) }
+
+// Cwd returns the launching session's working directory.
+func Cwd(h http.Header) string { return first(h, HeaderCwd, LegacyHeaderCwd) }
+
+// Router control-plane paths, served under the Messages API on the same local
+// port. Both spellings are served and probed for one release, for the same
+// mixed-install reason as the headers: a gremlord CLI must be able to
+// health-check and hot-reload an agentic router that still holds the port, or
+// leader election reads a healthy peer as a foreign process and refuses to
+// start.
+const (
+	PathHealth = "/gremlord/health"
+	PathReload = "/gremlord/reload"
+
+	LegacyPathHealth = "/agentic/health"
+	LegacyPathReload = "/agentic/reload"
+)

--- a/internal/wire/headers_test.go
+++ b/internal/wire/headers_test.go
@@ -1,0 +1,44 @@
+package wire
+
+import (
+	"net/http"
+	"testing"
+)
+
+// A pre-rename launcher's headers must still identify the session, or its spend
+// lands in the log with nothing to attribute it to.
+func TestReadersAcceptLegacySpelling(t *testing.T) {
+	h := http.Header{}
+	h.Set(LegacyHeaderSession, "sess")
+	h.Set(LegacyHeaderProfile, "main")
+	h.Set(LegacyHeaderPinModel, "opus")
+	h.Set(LegacyHeaderCwd, "/tmp/p")
+
+	if got := Session(h); got != "sess" {
+		t.Errorf("Session() = %q, want %q", got, "sess")
+	}
+	if got := Profile(h); got != "main" {
+		t.Errorf("Profile() = %q, want %q", got, "main")
+	}
+	if got := PinModel(h); got != "opus" {
+		t.Errorf("PinModel() = %q, want %q", got, "opus")
+	}
+	if got := Cwd(h); got != "/tmp/p" {
+		t.Errorf("Cwd() = %q, want %q", got, "/tmp/p")
+	}
+}
+
+func TestCurrentSpellingWins(t *testing.T) {
+	h := http.Header{}
+	h.Set(LegacyHeaderSession, "old")
+	h.Set(HeaderSession, "new")
+	if got := Session(h); got != "new" {
+		t.Errorf("Session() = %q, want %q", got, "new")
+	}
+}
+
+func TestMissingHeaderIsEmpty(t *testing.T) {
+	if got := Session(http.Header{}); got != "" {
+		t.Errorf("Session() = %q, want empty", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/maorbril/agentic/cmd"
+import "github.com/gremlord/gremlord/cmd"
 
 func main() {
 	cmd.Execute()

--- a/scripts/traffic-snapshot.sh
+++ b/scripts/traffic-snapshot.sh
@@ -12,7 +12,7 @@
 # endpoints need push access on the repo.
 set -euo pipefail
 
-REPO="MaorBril/agentic"
+REPO="gremlord/gremlord"
 DRY_RUN=0
 while [ $# -gt 0 ]; do
     case "$1" in


### PR DESCRIPTION
Renames the project end to end and carries existing installs across without data loss.

## Module, binary, name
- `go.mod` module is `github.com/gremlord/gremlord`; every import rewritten (69 files).
- ldflags version path updated in both `Makefile` and `.github/workflows/release.yml`.
- Binary, cobra command name, help text, error messages and printed output are all `gremlord`.
- Self-updater, `install.sh`, release workflow assets (`gremlord-$os-$arch`) and the embedded price feed all point at `gremlord/gremlord`.
- `GREMLORD_INSTALL_DIR` with `AGENTIC_INSTALL_DIR` as a fallback.

## Migration
`~/.agentic` is **copied, never moved**, to `~/.gremlord` on first run, through a staging directory renamed into place so two processes starting at once cannot interleave a half-copy.

Carried: `config.yaml`, `env`, `token`, `prices.json`, and the SQLite trio (db + `-wal` + `-shm`), preserving 0600 modes on key material.

Deliberately **not** carried, with reasons:
| Skipped | Why |
|---|---|
| `router.json` | Stale leader discovery would point the new binary at a dead port. |
| `router.log*` | Rotating log, regenerates on the next request. |
| `evals/`, `swebench-venv/` | 492 MB between them on the maintainer's machine, and both embed absolute paths — a Python venv does not survive being moved. Copying would duplicate a lot of disk to produce something broken. |

`gremlord doctor` names the leftover directory and lists what stayed behind, which is what the first-run notice points at.

Reads fall back to `~/.agentic` when a file is missing from `~/.gremlord`, so a copy that could not complete (unwritable home, full disk) degrades to reading the old location instead of silently starting from defaults with no keys and no budgets. Writes always go to the new directory, so installs converge.

The SQLite file keeps the name `agentic.db`. Renaming only the main file orphans its `-wal` sidecar, which is precisely the history the migration exists to preserve.

## Compatibility surfaces the rename would otherwise have broken
All three are reachable because the router is whichever binary won the port — a gremlord launcher can be talking to an agentic router, or the reverse.

1. **Request headers.** `X-Agentic-*` → `X-Gremlord-*`, written in both spellings and read in either. A reader that understood one spelling would drop session attribution and log spend that no session accounts for.
2. **Router control paths.** `/agentic/health` and `/agentic/reload` are still served, and the health probe tries both. Leader election decides whether to follow a peer by health-checking it, so a 404 here would read a healthy router as a foreign process and refuse to start.
3. **Subagent files.** Prefix is `gremlord-`, but the scan still recognises `agentic-`, so `gremlord agents sync` deletes the orphans instead of leaving two sets in Claude Code's picker. Same for the `<!-- agentic:peers -->` block in `CLAUDE.md`, which is rewritten in place rather than duplicated.

`GREMLORD_*` env vars win over `AGENTIC_*`, which stay readable for one release. The launcher writes both, because a `statusLine` hook in `~/.claude/settings.json` may still point at the old executable.

## Tests
New coverage for the risky paths: migration carries the right files and skips the rest, leaves the original byte-identical, is once-only, preserves 0600; read-through fallback and its convergence; `Getenv` precedence; legacy header reads and precedence; pre-rename subagent cleanup.

Verified: `go build ./...`, `go vet ./...`, `go test ./...` clean on a fresh clone. Migration exercised with a real binary against a synthetic `~/.agentic` — history read back correctly, notice printed once, original checksum unchanged. `doctor` passes fully on a clean install.

## Known follow-up
`assets/hero.gif` still shows the old command name. `assets/hero.tape` is updated, so it only needs re-recording — flagged as a TODO in the README rather than silently shipping a stale demo.