### PR TITLE
Make model evaluations harness-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ Three more things keep a session from spending window on nothing:
 
 ## Model evaluations
 
-`gremlord eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code in isolation, records router usage and route decisions under its own session ID, and produces a patch. An optional judge sees blinded patches and verifier evidence; it never sees model names, cost, or execution order.
+`gremlord eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code with a throwaway home, no user/project settings or MCP servers, no repository `CLAUDE.md`/`AGENTS.md`, and no subagents or web tools. It records router usage and route decisions under its own session ID and captures the complete submission relative to the pre-agent commit, including untracked, staged, and committed changes. `duration_ms` covers the candidate lifecycle while `agent_ms` isolates the agent turn (they are equal for local runs; Docker provisioning is excluded from `agent_ms`).
+
+An optional judge sees blinded patches and verifier evidence; it never sees model names, cost, or execution order. The judge is a direct Messages API request through the router rather than another Claude Code run, so its result is independent of the candidate harness.
 
 There are two executor types. A local manifest supplies its repository, setup command, and verifier directly:
 
@@ -374,7 +376,7 @@ Use `--task id` to select instances, `--seed` to reproduce launch order and judg
 
 A local verifier reports its verdict through its exit code: `0` passed, `2` "I could not judge this candidate" — a missing toolchain, an image that is not present, a container that would not start — and any other non-zero means the candidate's work is wrong. Exit `2` is recorded as `verifier_error`, an infrastructure status, so the pair is unscored, hidden from the judge, and retried by `--resume`. Without that distinction a machine missing a Docker image scores as a model loss, which is worse than no measurement at all.
 
-Artifacts include raw Claude output, patches, container logs, official SWE-bench reports, FAIL_TO_PASS/PASS_TO_PASS details, blinded judge mappings, per-candidate usage and route traces, pair results, the resolved dataset metadata/fingerprint, and `summary.json`. Local setup and verifier commands execute on the host, so review third-party local manifests before running them.
+Artifacts include raw Claude output, complete patches, container logs, official SWE-bench reports, FAIL_TO_PASS/PASS_TO_PASS details, blinded judge mappings, per-candidate usage and route traces, pair results, the resolved dataset metadata/fingerprint, and `summary.json`. Local setup and verifier commands execute on the host, so review third-party local manifests before running them.
 
 The router writes `~/.gremlord/router.log`. It is capped at 8 MiB and keeps three older generations (`router.log.1` … `.3`), so the log costs at most 32 MiB on disk. An oversized log left by an earlier version is rotated on the next write rather than truncated.
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Three more things keep a session from spending window on nothing:
 
 ## Model evaluations
 
-`gremlord eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code with a throwaway home, no user/project settings or MCP servers, no repository `CLAUDE.md`/`AGENTS.md`, and no subagents or web tools. It records router usage and route decisions under its own session ID and captures the complete submission relative to the pre-agent commit, including untracked, staged, and committed changes. `duration_ms` covers the candidate lifecycle while `agent_ms` isolates the agent turn (they are equal for local runs; Docker provisioning is excluded from `agent_ms`).
+`gremlord eval` compares a baseline model with a model under test on the same coding tasks. Each arm runs non-interactive Claude Code with a throwaway home, no user/project settings or MCP servers, no repository `CLAUDE.md`/`CLAUDE.local.md`/`AGENTS.md`/`AGENTS.override.md`, and no subagents or web tools. It records router usage and route decisions under its own session ID and captures the complete submission relative to the pre-agent commit, including untracked, staged, and committed changes. `duration_ms` covers the candidate lifecycle while `agent_ms` isolates the agent turn (they are equal for local runs; Docker provisioning is excluded from `agent_ms`).
 
 An optional judge sees blinded patches and verifier evidence; it never sees model names, cost, or execution order. The judge is a direct Messages API request through the router rather than another Claude Code run, so its result is independent of the candidate harness.
 

--- a/docs/harness-eval-plan.md
+++ b/docs/harness-eval-plan.md
@@ -1,6 +1,6 @@
 # Plan: evaluating Codex vs Claude Code as the base harness
 
-Status: proposal, 2026-09-08. Phase 0 implemented (uncommitted) 2026-09-08; Phases 1–5 not started.
+Status: proposal, 2026-09-08. Phase 0 implemented 2026-09-08; Phases 1–5 not started.
 
 ## The question
 

--- a/docs/harness-eval-plan.md
+++ b/docs/harness-eval-plan.md
@@ -1,0 +1,308 @@
+# Plan: evaluating Codex vs Claude Code as the base harness
+
+Status: proposal, 2026-09-08. Phase 0 implemented (uncommitted) 2026-09-08; Phases 1–5 not started.
+
+## The question
+
+gremlord wraps Claude Code and swaps what is behind `ANTHROPIC_BASE_URL`.
+OpenAI's Codex CLI is now Apache-2.0, Rust, and has first-class custom
+providers. Is its agent loop a better *harness* than Claude Code's — better
+patches per dollar on the same model — and should gremlord front it too?
+
+Nothing we have today answers this. `gremlord eval` holds Claude Code
+constant and varies the model (`internal/eval/eval.go:624`,
+`internal/eval/docker.go:212`). CLI aliases are rejected as candidates
+(`cmd/evalcmd.go:136-146`), and the `codex` provider in `internal/backend/clibe`
+is whole-task delegation from *inside* a Claude Code session — a composed
+system, not native Codex.
+
+The answer has to be measured. This plan makes the harness a factor in the
+existing evaluator and describes the experiment that isolates it.
+
+## Design principles
+
+1. **Reuse the evaluator.** Pairing, seeded launch order, blinded judge,
+   infra-vs-model failure taxonomy, official SWE-bench grading, artifacts,
+   and `--resume` all carry over. Only the candidate's *launch* is
+   harness-specific.
+2. **Harness × model is a crossed design, not a single pair.** A single
+   "GPT on Codex vs GPT on Claude Code" run confounds the harness with the
+   translation hop: Claude Code reaches OpenAI through gremlord's
+   Messages→Responses translation (which drops replayed thinking, sets
+   parallel tool calls false, omits server tools —
+   `internal/backend/openaibe/responses_request.go`), Codex speaks Responses
+   natively.
+3. **Both harnesses go through the router.** Cost attribution is router
+   telemetry keyed by session id (`eval.go:690-732`). A Codex arm pointed
+   straight at OpenAI shows $0 and cannot be compared on cost.
+4. **Everything not under test is pinned and recorded.** Harness version,
+   install command, model id, reasoning effort, context budget, sandbox
+   policy, tool restrictions — all in `environment.json` and the resume
+   fingerprint.
+
+## The experiment
+
+### Cells
+
+```
+                  Claude model          GPT model             open-weight (vLLM)
+Claude Code       native passthrough    Messages→Responses    Messages→Chat
+Codex             Responses→Messages    native passthrough    Responses→Chat
+```
+
+The **open-weight column is the primary signal.** There, both harnesses
+sit exactly one translation hop from the model through the same router
+code, so the harness main effect is estimable without a native/translated
+asymmetry. The diagonals are "harness-native" and the off-diagonals carry
+one translation hop; report them as secondary cells that estimate the
+harness×model interaction.
+
+### Decision rule
+
+- Codex beats Claude Code on resolve rate *or* cost-per-resolve in the
+  open-weight column, CI excluding zero → ship a Codex front-end
+  (`gremlord --harness codex`).
+- No difference → keep Claude Code only; `clibe` delegation stays as-is.
+- Strong harness×model interaction (each harness wins with its own vendor's
+  model) → the product answer is **routing harness per model family**, not
+  migration.
+
+### Metrics
+
+Primary: official SWE-bench `resolved`, paired per (instance, attempt),
+McNemar or paired bootstrap CI, task-clustered.
+
+Secondary, from the same run: cost per resolved instance (router
+telemetry), agent wall-clock (separate from provisioning), request count,
+tool-call count and error rate, patch size vs gold patch, empty/invalid
+patch rate, blinded judge score.
+
+### Power
+
+SWE-bench Verified resolve rates for frontier models sit in the 60–80%
+band. Detecting a ~5-point harness effect at 80% power needs on the order
+of 300+ paired instance-attempts per cell. Plan for a 10–20 instance
+integration pilot first, then a preregistered held-out set of ~100
+instances × 3 attempts. The one-instance smoke in the README is a smoke
+test, not a ranking.
+
+### Controls, per harness
+
+| Confound | Claude Code | Codex |
+|---|---|---|
+| Subagents | `--disallowedTools Task` (already) | `-c` under `[agents]` to disable; verify exact key against the pinned release |
+| Web tools | add `WebSearch,WebFetch` to `--disallowedTools` (not done today) | feature flag off |
+| User config / MCP / hooks / memories | fresh `HOME`, `--strict-mcp-config` with no servers | `--ignore-user-config --ignore-rules --ephemeral`, fresh `CODEX_HOME` |
+| Repo instruction files | no `CLAUDE.md` in `/testbed` | no `AGENTS.md` in `/testbed` |
+| Sandbox / approvals | `--permission-mode bypassPermissions` (already) | `--dangerously-bypass-approvals-and-sandbox` — the container *is* the sandbox; Codex's landlock inside Docker is a known failure mode and a confound if left on |
+| Reasoning effort | Claude Code sends thinking budgets | Codex sends `reasoning.effort` — **pin at the router per alias and ignore what the harness asks**; log what was pinned |
+| Model id, provider, max output | `X-Gremlord-Pin-Model` header (already) | same header via `http_headers` in the provider block; router owns the upstream id |
+| Declared context budget | virtual scaling (`docs/context-scaling.md`) | `model_context_window` / `model_auto_compact_token_limit` set to the same budget. Compaction *policy* is harness and stays in; the *declared budget* must match |
+| Tool schema deferral | `ENABLE_TOOL_SEARCH=false` pinned (`eval.go:948`) | n/a; record in fingerprint |
+| Harness version | `ClaudeCodeContainerVersion` (`docker.go:32`) | pin a Codex release tarball (linux x86_64 musl); record both |
+| Wall clock, attempts, seed | shared | shared |
+
+A second, later track relaxes the isolation and runs each harness with its
+native defaults (instruction files, subagents, web). That answers "which
+complete developer system is better", which is a different question and
+must be reported separately.
+
+## Implementation
+
+Phases are ordered so each one improves the evaluator we already have,
+even if the Codex work stops.
+
+### Phase 0 — fix the evaluator's existing fairness gaps
+
+These affect model-vs-model results today and would silently bias any
+harness comparison.
+
+- **Patch capture.** Both paths use `git diff --binary --no-ext-diff`
+  (`eval.go:644`, `docker.go:229`), which misses untracked files,
+  staged-only changes, and anything the agent committed. Capture the full
+  submission relative to the recorded base: `git add -A -N` + `git diff
+  <base>` or equivalent, in a way that excludes the harness's own
+  scratch files.
+- **Per-candidate isolation.** Local eval inherits `os.Environ()` and the
+  user's real `HOME` (`eval.go:922`). Give each candidate a throwaway
+  `HOME`/`CODEX_HOME`, no MCP, no hooks, no memories, and strip
+  instruction files from the workspace.
+- **Web tools off.** Add `WebSearch,WebFetch` to `--disallowedTools` for
+  Claude candidates so a task isn't solved by finding the upstream fix.
+- **Separate provisioning from agent time.** `RunDockerCandidate` folds
+  pull + install + turn into one `DurationMS` (`docker.go:163-167`).
+  Record `agent_ms` separately.
+- **Judge independence.** `runJudge` spawns `claude --print`
+  (`eval.go:743`). Replace with a direct Messages call to the router under
+  a `judge` session id so the judge isn't one of the arms under test.
+
+Acceptance: existing tests pass; a re-run of the smoke manifest produces
+identical verdicts with the new fields populated.
+
+Done 2026-09-08. Local and Docker paths now: intent-to-add + diff against the
+recorded pre-agent commit (excluding stripped `CLAUDE.md`/`AGENTS.md`);
+throwaway `HOME`/`CLAUDE_CONFIG_DIR`, `--strict-mcp-config` with empty
+servers, `--setting-sources ''`, instruction-file strip; `WebSearch,WebFetch`
+alongside `Task`; `agent_ms` separate from Docker provisioning; judge is a
+direct `/v1/messages` request. Tests and `go vet` pass; Claude CLI smoke
+accepted the new flag combination.
+
+### Phase 1 — a `Harness` seam in `internal/eval`
+
+Replace `Options.ClaudeBin` and the two hard-coded argv/env sites with an
+interface:
+
+```go
+type Harness interface {
+    Name() string                                  // "claude" | "codex"
+    Version() string                               // pinned
+    InstallCmd() []string                          // container install
+    Argv(bin, model, prompt string) []string
+    Env(e CandidateEnv) []string                   // base URL, token, session, pin, isolation
+    FinalText(stdout []byte) string
+    Usage(stdout []byte) (Usage, bool)             // harness-reported, if any
+    Fingerprint() map[string]string                // goes into environment.json + resume check
+}
+```
+
+Call sites: `eval.go:624,641-643,952`, `docker.go:85-91,108-133,203-215,501-502`.
+
+`CandidateResult` gains `Harness` and `HarnessVersion`. `sessionID`
+(`eval.go:1001`) and `swebenchFingerprint` (`docker.go:451`) must include
+the harness, or two harness runs at the same seed merge their spend — the
+same bug PR #19 fixed for models.
+
+`ClaudeHarness` is the current behaviour extracted verbatim, plus the
+Phase 0 isolation flags. Tests in `eval_test.go` and `docker_test.go`
+that match on `"claude"` in argv become table-driven over both harnesses.
+
+Acceptance: `--harness claude` (default) is byte-identical in behaviour to
+today; `go test ./internal/eval/...` passes with the seam.
+
+### Phase 2 — `CodexHarness`
+
+Local invocation:
+
+```
+codex exec --json --ephemeral --ignore-user-config --ignore-rules \
+  --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
+  -C <workspace> --model <alias> -o <final.md> <prompt>
+```
+
+- `Env`: `CODEX_HOME=<tmp>` containing a generated `config.toml` with one
+  provider block pointing at the router:
+
+  ```toml
+  model_provider = "gremlord"
+  [model_providers.gremlord]
+  name = "gremlord"
+  base_url = "http://127.0.0.1:PORT/v1"     # relay URL in Docker
+  env_key = "GREMLORD_TOKEN"
+  wire_api = "responses"
+  http_headers = { "X-Gremlord-Session" = "...", "X-Gremlord-Pin-Model" = "...", "X-Gremlord-Profile" = "..." }
+  ```
+
+  plus `model_context_window` / `model_auto_compact_token_limit` set from
+  the alias's configured budget, and `[agents]` / web features disabled.
+- `FinalText`: read `-o` file; fall back to the last `item.*` agent
+  message in the JSONL.
+- `Usage`: sum `turn.completed.usage` events. This is the harness's view;
+  the router's telemetry remains authoritative for cost. Record both and
+  flag disagreement.
+- `InstallCmd`: pinned release tarball URL for `rust-vX.Y.Z` linux
+  x86_64 musl, unpacked to `/usr/local/bin/codex`. Verify with
+  `codex --version`.
+- Terminal-event validation: treat a run that ends without
+  `turn.completed` or `turn.failed` as `model_error`, not `complete`.
+- Process-tree cleanup on timeout (Codex spawns shell children).
+
+Acceptance: a local-manifest smoke task runs end-to-end under
+`--harness codex` against the current router with an **OpenAI Responses
+alias** (see Phase 3 — until then the router will not accept the request;
+this phase's tests use a fake executor).
+
+### Phase 3 — Responses inbound on the router
+
+Codex only speaks `wire_api = "responses"`. gremlord listens on
+`/v1/messages` and forwards unknown `/v1/*` to Anthropic
+(`internal/router/server.go:83-87`). Without this phase no Codex arm can be
+metered or routed.
+
+- `POST /v1/responses` handler beside `handleMessages`. Auth, session /
+  pin / profile headers, budget gate, usage log, pricing, and the
+  pin-remap backstop (`server.go:141-154`) are shared.
+- Dispatch:
+  - resolved provider is OpenAI/Responses → passthrough, byte-faithful
+    where possible (mirror of the anthropic passthrough).
+  - resolved provider is Anthropic → new `responses→messages` request
+    translator and `messages→responses` response/stream translator.
+  - resolved provider is Chat Completions (vLLM, xAI, Ollama) →
+    `responses→chat` and back.
+- Hard parts, mirrored from the existing translator: reasoning items
+  round-trip (Codex expects encrypted reasoning content back; Anthropic
+  gives signed thinking blocks), `previous_response_id` / `store`
+  semantics (reject `store=true`, require full input each turn), no
+  `cache_control` equivalent so Claude prompt caching must be synthesised
+  at the router for Codex→Claude, tool-call id formats.
+- Scope guard: this is enough for **eval traffic** — one process, full
+  input each turn, no `previous_response_id`, no server tools. Interactive
+  Codex sessions may need more; do not block the eval on that.
+
+Size estimate: the existing outbound translator is ~1,600 lines including
+tests (`internal/backend/openaibe/`). Expect the same again.
+
+Acceptance: contract tests for both translators (tool call, tool result,
+multi-turn, streaming, reasoning round-trip); a Codex smoke run against a
+Claude alias and an Anthropic-key-free run against a vLLM alias both
+produce priced usage rows keyed to the eval session id.
+
+### Phase 4 — cell orchestration and reporting
+
+- Manifest or flags express cells: `--baseline-harness`, `--mut-harness`
+  alongside the existing `--baseline` / `--mut` model flags; or a `cells:`
+  block that expands to pairs. Keep the pair abstraction — a cell
+  comparison is still baseline-vs-mut, it's just that harness may differ.
+- `Summary` gains per-cell aggregates and an interaction table
+  (harness × model, resolve rate with CI).
+- `gremlord eval report` prints the table; `--json` emits it.
+- Resume checks compare the full fingerprint (harness, version, install,
+  model resolution, pinned effort, budget), not just model + seed
+  (`eval.go:483-486`).
+
+### Phase 5 — run it
+
+1. Pilot: 10–20 SWE-bench Verified instances × 2 attempts, open-weight
+   column only, to shake out infra. Expect infra failures; that's what
+   `--resume` is for.
+2. Preregister: fix the instance list, attempts, seed, pinned versions,
+   pinned effort, and the decision rule above before the main run.
+3. Main run: ~100 instances × 3 attempts × 6 cells. Budget time for x86_64
+   emulation on Apple Silicon or run on a Linux box.
+4. Report with the decision rule applied. If the answer is "route per
+   model family", that's a config change in the router, not a rewrite.
+
+## Out of scope for this plan
+
+- `gremlord --harness codex` for interactive sessions (statusline, tier
+  env vars, `gremlord peers`, `agents sync`, Auto Goal). Gated on the
+  eval result.
+- Forking Codex. Stock CLI for measurement; app-server for deeper
+  integration if ever needed; fork only for a demonstrated requirement.
+- Cross-harness parity of `CLAUDE.md` vs `AGENTS.md` semantics. Both are
+  excluded in the controlled track and left native in the realistic track.
+
+## Open questions
+
+- Which open-weight model(s) for the primary column? glm53 and kimi-k3 are
+  configured; pick the one with the more stable vLLM endpoint and a
+  Responses *or* Chat surface we can translate to without new work.
+- Codex `[agents]` config key for disabling subagents in the pinned
+  release — confirm against that release's `config.md`, not the docs site.
+- Does the pinned Codex build honour `http_headers` for non-OpenAI
+  providers on every request, including retries? If not, session
+  attribution needs `env_http_headers` or a proxy-side fallback.
+- Two claims surfaced during research that would affect the strategic
+  weight but were not verified: a mid-2026 Claude Code proxy-fingerprinting
+  incident, and an Anthropic policy change on subscription use via
+  third-party harnesses. Check the primary sources before either
+  influences a decision.

--- a/internal/eval/docker.go
+++ b/internal/eval/docker.go
@@ -224,7 +224,7 @@ func RunDockerCandidate(ctx context.Context, opts DockerOptions, instance SWEBen
 		return res
 	}
 	isolateCtx, isolateCancel := context.WithTimeout(ctx, opts.execTimeout())
-	ignoredOut, _, err := dockerExec(isolateCtx, opts, nil, []string{"bash", "-lc", `rm -rf /tmp/gremlord-eval-home && install -d -m 0700 -o nonroot -g nonroot /tmp/gremlord-eval-home && find /testbed -path /testbed/.git -prune -o -type f \( -iname CLAUDE.md -o -iname AGENTS.md \) -print -delete`}, &log, false, containerID)
+	ignoredOut, _, err := dockerExec(isolateCtx, opts, nil, []string{"bash", "-lc", `rm -rf /tmp/gremlord-eval-home && install -d -m 0700 -o nonroot -g nonroot /tmp/gremlord-eval-home && find /testbed -path /testbed/.git -prune -o -type f \( -iname CLAUDE.md -o -iname CLAUDE.local.md -o -iname AGENTS.md -o -iname AGENTS.override.md \) -print -delete`}, &log, false, containerID)
 	isolateCancel()
 	if err != nil {
 		res.Status, res.Error = StatusDockerError, "isolate candidate: "+err.Error()
@@ -260,15 +260,42 @@ func RunDockerCandidate(ctx context.Context, opts DockerOptions, instance SWEBen
 	}
 
 	diffCtx, diffCancel := context.WithTimeout(ctx, opts.execTimeout())
+	defer diffCancel()
+	for _, path := range ignoredInstructions {
+		if path == "" {
+			continue
+		}
+		full := dockerWorkdir + "/" + path
+		_, _, missing := dockerExec(diffCtx, opts, nil, []string{"test", "-e", full}, &log, true, containerID)
+		if missing == nil {
+			continue
+		}
+		if _, _, err := dockerExec(diffCtx, opts, nil, []string{"git", "cat-file", "-e", base + ":" + path}, &log, true, containerID); err != nil {
+			continue
+		}
+		if _, _, err := dockerExec(diffCtx, opts, nil, []string{"git", "checkout", base, "--", path}, &log, false, containerID); err != nil {
+			if res.Status == StatusComplete {
+				res.Status, res.Error = StatusDockerError, "restore instructions: "+err.Error()
+			}
+			res.ContainerLog = log.Bytes()
+			return res
+		}
+	}
 	_, _, aerr := dockerExec(diffCtx, opts, nil, []string{"git", "add", "-A", "-N"}, &log, false, containerID)
 	if aerr != nil {
-		logf("git add --intent-to-add: %v", aerr)
+		if res.Status == StatusComplete {
+			res.Status, res.Error = StatusDockerError, "git add --intent-to-add: "+aerr.Error()
+		}
+		res.ContainerLog = log.Bytes()
+		return res
 	}
-	diffArgs := append([]string{"git", "diff", base, "--binary", "--no-ext-diff"}, patchIgnoreArgs(ignoredInstructions)...)
-	patch, _, perr := dockerExec(diffCtx, opts, nil, diffArgs, &log, false, containerID)
-	diffCancel()
+	patch, _, perr := dockerExec(diffCtx, opts, nil, []string{"git", "diff", base, "--binary", "--no-ext-diff"}, &log, false, containerID)
 	if perr != nil {
-		logf("git diff: %v", perr)
+		if res.Status == StatusComplete {
+			res.Status, res.Error = StatusDockerError, "git diff: "+perr.Error()
+		}
+		res.ContainerLog = log.Bytes()
+		return res
 	}
 	res.Patch = string(patch)
 	res.ContainerLog = log.Bytes()

--- a/internal/eval/docker.go
+++ b/internal/eval/docker.go
@@ -107,7 +107,8 @@ type DockerContainerEnv struct {
 
 func containerEnvArgs(e DockerContainerEnv) []string {
 	return []string{
-		"HOME=/home/nonroot",
+		"HOME=/tmp/gremlord-eval-home",
+		"CLAUDE_CONFIG_DIR=/tmp/gremlord-eval-home/.claude",
 		"USER=nonroot",
 		"ANTHROPIC_BASE_URL=" + e.BaseURL,
 		"ANTHROPIC_AUTH_TOKEN=" + e.Token,
@@ -129,6 +130,10 @@ func containerEnvArgs(e DockerContainerEnv) []string {
 		"ANTHROPIC_DEFAULT_SONNET_MODEL=" + e.Model,
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL=" + e.Model,
 		"CLAUDE_CODE_SUBAGENT_MODEL=" + e.Model,
+		// Same pin as local evalEnv: interactive sessions inherit
+		// ENABLE_TOOL_SEARCH=true, and comparability must not depend on
+		// where the eval was launched from.
+		"ENABLE_TOOL_SEARCH=false",
 	}
 }
 
@@ -140,6 +145,7 @@ type DockerCandidateResult struct {
 	Error      string
 	ExitCode   int
 	DurationMS int64
+	AgentMS    int64
 	Stdout     []byte
 	Stderr     []byte
 	Patch      string
@@ -209,10 +215,38 @@ func RunDockerCandidate(ctx context.Context, opts DockerOptions, instance SWEBen
 	}
 	logf("claude code installed at %s", claudePath)
 
-	argv := []string{claudePath, "--print", "--output-format", "json", "--permission-mode", "bypassPermissions", "--disallowedTools", "Task", "--model", model, prompt}
+	baseCtx, baseCancel := context.WithTimeout(ctx, opts.execTimeout())
+	baseOut, _, err := dockerExec(baseCtx, opts, nil, []string{"git", "rev-parse", "HEAD"}, &log, false, containerID)
+	baseCancel()
+	base := strings.TrimSpace(string(baseOut))
+	if err != nil || base == "" {
+		res.Status, res.Error = StatusDockerError, "record workspace base: "+fmt.Sprint(err)
+		return res
+	}
+	isolateCtx, isolateCancel := context.WithTimeout(ctx, opts.execTimeout())
+	ignoredOut, _, err := dockerExec(isolateCtx, opts, nil, []string{"bash", "-lc", `rm -rf /tmp/gremlord-eval-home && install -d -m 0700 -o nonroot -g nonroot /tmp/gremlord-eval-home && find /testbed -path /testbed/.git -prune -o -type f \( -iname CLAUDE.md -o -iname AGENTS.md \) -print -delete`}, &log, false, containerID)
+	isolateCancel()
+	if err != nil {
+		res.Status, res.Error = StatusDockerError, "isolate candidate: "+err.Error()
+		return res
+	}
+	var ignoredInstructions []string
+	for _, path := range strings.Split(string(ignoredOut), "\n") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if rel := strings.TrimPrefix(path, dockerWorkdir+"/"); rel != path && rel != "" {
+			ignoredInstructions = append(ignoredInstructions, rel)
+		}
+	}
+
+	argv := candidateArgs(claudePath, model, prompt)
 	env := containerEnvArgs(containerEnv)
 	turnCtx, turnCancel := context.WithTimeout(ctx, claudeTimeout)
+	agentStart := time.Now()
 	stdout, stderr, err := dockerExecUser(turnCtx, opts, env, argv, &log, false, containerID, "nonroot")
+	res.AgentMS = time.Since(agentStart).Milliseconds()
 	turnCancel()
 	res.Stdout, res.Stderr = stdout, stderr
 	res.ExitCode = dockerExitCode(err)
@@ -226,7 +260,12 @@ func RunDockerCandidate(ctx context.Context, opts DockerOptions, instance SWEBen
 	}
 
 	diffCtx, diffCancel := context.WithTimeout(ctx, opts.execTimeout())
-	patch, _, perr := dockerExec(diffCtx, opts, nil, []string{"git", "diff", "--binary", "--no-ext-diff"}, &log, false, containerID)
+	_, _, aerr := dockerExec(diffCtx, opts, nil, []string{"git", "add", "-A", "-N"}, &log, false, containerID)
+	if aerr != nil {
+		logf("git add --intent-to-add: %v", aerr)
+	}
+	diffArgs := append([]string{"git", "diff", base, "--binary", "--no-ext-diff"}, patchIgnoreArgs(ignoredInstructions)...)
+	patch, _, perr := dockerExec(diffCtx, opts, nil, diffArgs, &log, false, containerID)
 	diffCancel()
 	if perr != nil {
 		logf("git diff: %v", perr)
@@ -495,7 +534,7 @@ func (r *Runner) runSWEBenchCandidate(ctx context.Context, manifest *Manifest, t
 	run := RunDockerCandidate(ctx, r.Options.Docker, instance, task.Prompt, model, r.Options.Timeout, DockerContainerEnv{
 		BaseURL: r.relay.ContainerURL, Token: r.Options.Token, SessionID: res.SessionID, Profile: r.Options.Profile, Model: model,
 	})
-	res.Status, res.Error, res.ExitCode, res.DurationMS = run.Status, run.Error, run.ExitCode, run.DurationMS
+	res.Status, res.Error, res.ExitCode, res.DurationMS, res.AgentMS = run.Status, run.Error, run.ExitCode, run.DurationMS, run.AgentMS
 	res.FinalText = finalText(run.Stdout)
 	res.Patch = run.Patch
 	os.WriteFile(filepath.Join(dir, "claude.stdout.json"), run.Stdout, 0o644)

--- a/internal/eval/docker_test.go
+++ b/internal/eval/docker_test.go
@@ -35,7 +35,10 @@ case "$1" in
     case "$all" in
       *"registry.npmjs.org/@anthropic-ai/claude-code-linux-x64"*) exit 0 ;;
       *"command -v claude"*) printf '/usr/local/bin/claude\n'; exit 0 ;;
-      *"git diff --binary --no-ext-diff"*) printf '%s' "${FAKE_DOCKER_PATCH:-}"; exit 0 ;;
+      *"git rev-parse HEAD"*) printf 'base-sha\n'; exit 0 ;;
+      *"git add -A -N"*) exit 0 ;;
+      *"iname CLAUDE.md"*) printf '/testbed/CLAUDE.md\n'; exit 0 ;;
+      *"git diff base-sha --binary --no-ext-diff"*) printf '%s' "${FAKE_DOCKER_PATCH:-}"; exit 0 ;;
       *"/usr/local/bin/claude --print"*)
         if [ "${FAKE_DOCKER_CLAUDE_FAIL:-}" = "1" ]; then echo "candidate failed" >&2; exit 7; fi
         printf '%s' "${FAKE_DOCKER_CLAUDE_OUT:-{\"result\":\"done\"}}"
@@ -69,7 +72,7 @@ func TestRunDockerCandidateLifecycleAndRedaction(t *testing.T) {
 	}, "fix the bug", "auto", time.Minute, DockerContainerEnv{
 		BaseURL: "http://host.docker.internal:41234", Token: "super-secret", SessionID: "eval-session", Profile: "main",
 	})
-	if result.Status != StatusComplete || result.ExitCode != 0 || !strings.Contains(result.Patch, "+new") {
+	if result.Status != StatusComplete || result.ExitCode != 0 || result.AgentMS > result.DurationMS || !strings.Contains(result.Patch, "+new") {
 		t.Fatalf("result = %+v", result)
 	}
 	if !strings.Contains(string(result.Stdout), `"result":"done"`) {
@@ -81,7 +84,7 @@ func TestRunDockerCandidateLifecycleAndRedaction(t *testing.T) {
 	}
 	for _, want := range []string{
 		"docker run", "claude code installed", "ANTHROPIC_AUTH_TOKEN=<redacted>",
-		"ANTHROPIC_BASE_URL=<redacted>", "git diff --binary --no-ext-diff",
+		"ANTHROPIC_BASE_URL=<redacted>", "git add -A -N", "git diff base-sha --binary --no-ext-diff",
 	} {
 		if !strings.Contains(log, want) {
 			t.Errorf("container log missing %q:\n%s", want, log)
@@ -94,8 +97,11 @@ func TestRunDockerCandidateLifecycleAndRedaction(t *testing.T) {
 	if !strings.Contains(string(calls), "rm -f container-123") {
 		t.Errorf("container was not removed:\n%s", calls)
 	}
-	if !strings.Contains(string(calls), "-u nonroot") || !strings.Contains(string(calls), "HOME=/home/nonroot") {
+	if !strings.Contains(string(calls), "-u nonroot") || !strings.Contains(string(calls), "HOME=/tmp/gremlord-eval-home") || !strings.Contains(string(calls), "--strict-mcp-config") {
 		t.Errorf("candidate did not run as nonroot:\n%s", calls)
+	}
+	if !strings.Contains(string(calls), ":(exclude)CLAUDE.md") {
+		t.Errorf("harness instruction removal was not excluded from the patch:\n%s", calls)
 	}
 	if !strings.Contains(string(calls), "X-Agentic-Session: eval-session") || !strings.Contains(string(calls), "X-Agentic-Profile: main") {
 		t.Errorf("session/profile env missing:\n%s", calls)
@@ -143,6 +149,7 @@ func TestDockerContainerEnvAndArgRedaction(t *testing.T) {
 		"ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.6-sol",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-5.6-sol",
 		"CLAUDE_CODE_SUBAGENT_MODEL=gpt-5.6-sol",
+		"ENABLE_TOOL_SEARCH=false",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("env missing %q: %s", want, joined)

--- a/internal/eval/docker_test.go
+++ b/internal/eval/docker_test.go
@@ -38,7 +38,12 @@ case "$1" in
       *"git rev-parse HEAD"*) printf 'base-sha\n'; exit 0 ;;
       *"git add -A -N"*) exit 0 ;;
       *"iname CLAUDE.md"*) printf '/testbed/CLAUDE.md\n'; exit 0 ;;
-      *"git diff base-sha --binary --no-ext-diff"*) printf '%s' "${FAKE_DOCKER_PATCH:-}"; exit 0 ;;
+      *"test -e "*) exit 1 ;;
+      *"git cat-file -e"*) exit 0 ;;
+      *"git checkout base-sha --"*) exit 0 ;;
+      *"git diff base-sha --binary --no-ext-diff"*)
+        if [ "${FAKE_DOCKER_DIFF_FAIL:-}" = "1" ]; then echo "diff failed" >&2; exit 1; fi
+        printf '%s' "${FAKE_DOCKER_PATCH:-}"; exit 0 ;;
       *"/usr/local/bin/claude --print"*)
         if [ "${FAKE_DOCKER_CLAUDE_FAIL:-}" = "1" ]; then echo "candidate failed" >&2; exit 7; fi
         printf '%s' "${FAKE_DOCKER_CLAUDE_OUT:-{\"result\":\"done\"}}"
@@ -100,8 +105,8 @@ func TestRunDockerCandidateLifecycleAndRedaction(t *testing.T) {
 	if !strings.Contains(string(calls), "-u nonroot") || !strings.Contains(string(calls), "HOME=/tmp/gremlord-eval-home") || !strings.Contains(string(calls), "--strict-mcp-config") {
 		t.Errorf("candidate did not run as nonroot:\n%s", calls)
 	}
-	if !strings.Contains(string(calls), ":(exclude)CLAUDE.md") {
-		t.Errorf("harness instruction removal was not excluded from the patch:\n%s", calls)
+	if !strings.Contains(string(calls), "iname CLAUDE.local.md") || !strings.Contains(string(calls), "git checkout base-sha -- CLAUDE.md") {
+		t.Errorf("harness instruction isolation/restore missing:\n%s", calls)
 	}
 	if !strings.Contains(string(calls), "X-Agentic-Session: eval-session") || !strings.Contains(string(calls), "X-Agentic-Profile: main") {
 		t.Errorf("session/profile env missing:\n%s", calls)
@@ -135,6 +140,18 @@ func TestRunDockerCandidateClassifiesInfrastructureAndModelFailures(t *testing.T
 			t.Fatalf("result = %+v", result)
 		}
 	})
+}
+
+func TestRunDockerCandidateCaptureFailureIsInfrastructure(t *testing.T) {
+	dir := t.TempDir()
+	withFakeDockerEnv(t, dir)
+	t.Setenv("FAKE_DOCKER_DIFF_FAIL", "1")
+	result := RunDockerCandidate(context.Background(), DockerOptions{DockerBin: fakeDocker(t, dir)}, SWEBenchInstance{
+		InstanceImageKey: "image:latest",
+	}, "prompt", "auto", time.Minute, DockerContainerEnv{})
+	if result.Status != StatusDockerError || !strings.Contains(result.Error, "git diff") {
+		t.Fatalf("result = %+v", result)
+	}
 }
 
 func TestDockerContainerEnvAndArgRedaction(t *testing.T) {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/gremlord/gremlord/internal/anthropic"
 	"github.com/gremlord/gremlord/internal/config"
 	"github.com/gremlord/gremlord/internal/store"
 
@@ -289,6 +291,7 @@ type CandidateResult struct {
 	SessionID  string         `json:"session_id"`
 	Status     string         `json:"status"`
 	DurationMS int64          `json:"duration_ms"`
+	AgentMS    int64          `json:"agent_ms"`
 	ExitCode   int            `json:"exit_code"`
 	FinalText  string         `json:"final_text,omitempty"`
 	Patch      string         `json:"patch,omitempty"`
@@ -407,6 +410,7 @@ func (OSExecutor) Run(ctx context.Context, dir string, env, argv []string, stdin
 type Runner struct {
 	Options     Options
 	Exec        Executor
+	JudgeClient *http.Client
 	OnCandidate func(CandidateResult)
 
 	// Dataset-only runtime state, populated once at the start of Run. The
@@ -620,15 +624,32 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 		res.Verifier.Skipped = "setup failed"
 		return res, nil
 	}
+	base := strings.TrimSpace(gitOutput(ctx, workspace, "rev-parse", "HEAD"))
+	if base == "" {
+		res.Status, res.Error = StatusWorkspaceError, "workspace has no base commit"
+		res.Verifier.Skipped = "workspace base could not be recorded"
+		return res, nil
+	}
+	ignoredInstructions, err := stripHarnessInstructions(workspace)
+	if err != nil {
+		res.Status, res.Error = StatusWorkspaceError, "strip harness instructions: "+err.Error()
+		res.Verifier.Skipped = "workspace isolation failed"
+		return res, nil
+	}
+	home := filepath.Join(dir, "home")
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return res, err
+	}
 
-	argv := []string{r.Options.ClaudeBin, "--print", "--output-format", "json", "--permission-mode", "bypassPermissions", "--disallowedTools", "Task", "--model", model, task.Prompt}
-	env := evalEnv(os.Environ(), r.Options, res.SessionID, model)
+	argv := candidateArgs(r.Options.ClaudeBin, model, task.Prompt)
+	env := evalEnv(os.Environ(), r.Options, res.SessionID, model, home)
 	var stdout, stderr bytes.Buffer
 	start := time.Now()
 	runCtx, cancel := context.WithTimeout(ctx, r.Options.Timeout)
-	err := r.Exec.Run(runCtx, workspace, env, argv, nil, &stdout, &stderr)
+	err = r.Exec.Run(runCtx, workspace, env, argv, nil, &stdout, &stderr)
 	cancel()
 	res.DurationMS = time.Since(start).Milliseconds()
+	res.AgentMS = res.DurationMS
 	res.ExitCode = exitCode(err)
 	switch {
 	case errors.Is(runCtx.Err(), context.DeadlineExceeded):
@@ -641,7 +662,7 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 	os.WriteFile(filepath.Join(dir, "claude.stdout.json"), stdout.Bytes(), 0o644)
 	os.WriteFile(filepath.Join(dir, "claude.stderr.log"), stderr.Bytes(), 0o644)
 	res.FinalText = finalText(stdout.Bytes())
-	res.Patch = gitOutput(ctx, workspace, "diff", "--binary", "--no-ext-diff")
+	res.Patch = capturePatch(ctx, workspace, base, ignoredInstructions)
 	os.WriteFile(filepath.Join(dir, "patch.diff"), []byte(res.Patch), 0o644)
 
 	if res.ModelFailed() {
@@ -666,6 +687,10 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 		return res, err
 	}
 	return res, nil
+}
+
+func candidateArgs(bin, model, prompt string) []string {
+	return []string{bin, "--print", "--output-format", "json", "--permission-mode", "bypassPermissions", "--strict-mcp-config", "--mcp-config", `{"mcpServers":{}}`, "--setting-sources", "", "--disallowedTools", "Task,WebSearch,WebFetch", "--model", model, prompt}
 }
 
 // firstLine is the most useful part of a verifier's output for an error
@@ -740,7 +765,6 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 		mapping["candidate_1"], mapping["candidate_2"] = "mut", "baseline"
 	}
 	prompt := judgePrompt(task, first, second)
-	argv := []string{r.Options.ClaudeBin, "--print", "--output-format", "json", "--permission-mode", "bypassPermissions", "--disallowedTools", "Task", "--model", r.Options.Judge, prompt}
 	sid := sessionID(r.Options.Seed, task.ID, attempt, "judge", r.Options.Judge)
 	var stdout, stderr bytes.Buffer
 	judgeDir := filepath.Join(pairDir, "judge")
@@ -752,7 +776,7 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 		return JudgeResult{}, "", err
 	}
 	judgeCtx, cancel := context.WithTimeout(ctx, r.Options.Timeout)
-	err := r.Exec.Run(judgeCtx, workDir, evalEnv(os.Environ(), r.Options, sid, r.Options.Judge), argv, nil, &stdout, &stderr)
+	text, err := r.callJudge(judgeCtx, sid, prompt, &stdout, &stderr)
 	cancel()
 	os.WriteFile(filepath.Join(judgeDir, "stdout.json"), stdout.Bytes(), 0o644)
 	os.WriteFile(filepath.Join(judgeDir, "stderr.log"), stderr.Bytes(), 0o644)
@@ -761,7 +785,7 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 		return JudgeResult{}, "", fmt.Errorf("judge: %w", err)
 	}
 	var result JudgeResult
-	if err := json.Unmarshal([]byte(finalText(stdout.Bytes())), &result); err != nil {
+	if err := json.Unmarshal([]byte(text), &result); err != nil {
 		return JudgeResult{}, "", fmt.Errorf("judge returned invalid JSON: %w", err)
 	}
 	if result.Winner != "candidate_1" && result.Winner != "candidate_2" && result.Winner != WinnerTie {
@@ -773,6 +797,58 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 	}
 	writeJSONAtomic(filepath.Join(judgeDir, "result.json"), result)
 	return result, winner, nil
+}
+
+func (r *Runner) callJudge(ctx context.Context, sid, prompt string, stdout, stderr io.Writer) (string, error) {
+	body, err := json.Marshal(anthropic.MessagesRequest{
+		Model: r.Options.Judge, MaxTokens: 1024,
+		Messages: []anthropic.Message{{Role: "user", Content: anthropic.MessageBody{{Type: "text", Text: prompt}}}},
+	})
+	if err != nil {
+		return "", err
+	}
+	url := strings.TrimSuffix(r.Options.BaseURL, "/") + "/v1/messages"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", r.Options.Token)
+	req.Header.Set(wire.HeaderSession, sid)
+	req.Header.Set(wire.HeaderProfile, r.Options.Profile)
+	req.Header.Set(wire.HeaderPinModel, r.Options.Judge)
+	client := r.JudgeClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, readErr := io.ReadAll(resp.Body)
+	_, _ = stdout.Write(data)
+	if readErr != nil {
+		return "", readErr
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = fmt.Fprintf(stderr, "HTTP %d: %s", resp.StatusCode, data)
+		return "", fmt.Errorf("router returned HTTP %d: %s", resp.StatusCode, truncate(strings.TrimSpace(string(data)), 1000))
+	}
+	var message anthropic.MessagesResponse
+	if err := json.Unmarshal(data, &message); err != nil {
+		return "", fmt.Errorf("decode Messages response: %w", err)
+	}
+	var text strings.Builder
+	for _, block := range message.Content {
+		if block.Type == "text" {
+			text.WriteString(block.Text)
+		}
+	}
+	if strings.TrimSpace(text.String()) == "" {
+		return "", errors.New("Messages response contained no text")
+	}
+	return strings.TrimSpace(text.String()), nil
 }
 
 func judgePrompt(task Task, a, b CandidateResult) string {
@@ -851,6 +927,35 @@ func (s *Summary) aggregate() {
 	}
 }
 
+func stripHarnessInstructions(root string) ([]string, error) {
+	var removed []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if path != root && entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := strings.ToLower(entry.Name())
+		if name != "claude.md" && name != "agents.md" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+		removed = append(removed, filepath.ToSlash(rel))
+		return nil
+	})
+	return removed, err
+}
+
 // prepareWorkspace clones the task repository and checks out its base. SWE-bench
 // manifests pin a commit SHA, which `git clone --branch` rejects, so the
 // checkout is a separate detached step that accepts a branch, tag, or SHA.
@@ -919,7 +1024,11 @@ func verify(ctx context.Context, ex Executor, dir string, c Command, logPath str
 	return v
 }
 
-func evalEnv(env []string, o Options, sid, model string) []string {
+func evalEnv(env []string, o Options, sid, model string, homes ...string) []string {
+	if len(homes) > 0 && homes[0] != "" {
+		env = setEnv(env, "HOME", homes[0])
+		env = setEnv(env, "CLAUDE_CONFIG_DIR", filepath.Join(homes[0], ".claude"))
+	}
 	env = setEnv(env, "ANTHROPIC_BASE_URL", o.BaseURL)
 	env = setEnv(env, "ANTHROPIC_AUTH_TOKEN", o.Token)
 	env = unsetEnv(env, "ANTHROPIC_API_KEY")
@@ -961,6 +1070,31 @@ func finalText(data []byte) string {
 		}
 	}
 	return strings.TrimSpace(string(data))
+}
+
+func capturePatch(ctx context.Context, dir, base string, ignore []string) string {
+	// Intent-to-add makes untracked files visible to `git diff` without staging
+	// their contents. Diffing against the immutable pre-agent commit also
+	// includes staged changes and commits the candidate may have created.
+	add := exec.CommandContext(ctx, "git", "-C", dir, "add", "-A", "-N")
+	_ = add.Run()
+	args := []string{"diff", base, "--binary", "--no-ext-diff"}
+	args = append(args, patchIgnoreArgs(ignore)...)
+	return gitOutput(ctx, dir, args...)
+}
+
+// Isolation removed harness instruction files (CLAUDE.md/AGENTS.md) before
+// the candidate ran. That removal is a harness action, not the candidate's
+// work, and must not appear in the submitted patch.
+func patchIgnoreArgs(ignore []string) []string {
+	if len(ignore) == 0 {
+		return nil
+	}
+	args := []string{"--", "."}
+	for _, path := range ignore {
+		args = append(args, ":(exclude)"+path)
+	}
+	return args
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) string {

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -31,6 +31,10 @@ import (
 
 const SchemaVersion = 1
 
+// judgeMaxTokens is large enough for a blinded JSON verdict with a
+// reasoned comparison. Truncation is treated as a missing measurement.
+const judgeMaxTokens = 4096
+
 // Candidate outcome states. Only StatusComplete means the model actually
 // finished its turn; the others separate model failure (timeout, non-zero
 // exit) from harness/infrastructure failure (workspace, setup, Docker
@@ -485,6 +489,7 @@ func (r *Runner) Run(ctx context.Context, manifest *Manifest) (*Summary, error) 
 				return nil, err
 			}
 			if old.Baseline != r.Options.Baseline || old.MUT != r.Options.MUT || old.Seed != r.Options.Seed ||
+				old.Judge != r.Options.Judge ||
 				old.DatasetFingerprint != s.DatasetFingerprint || old.SWEBenchVersion != s.SWEBenchVersion {
 				return nil, fmt.Errorf("resume options or benchmark environment do not match existing run")
 			}
@@ -624,8 +629,17 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 		res.Verifier.Skipped = "setup failed"
 		return res, nil
 	}
-	base := strings.TrimSpace(gitOutput(ctx, workspace, "rev-parse", "HEAD"))
-	if base == "" {
+	// Setup is harness work. Commit it before recording the patch base so
+	// uncommitted setup edits are not attributed to the candidate, and so
+	// committed setup is part of the base the patch applies to.
+	if err := commitHarnessChanges(ctx, workspace, "gremlord eval setup"); err != nil {
+		res.Status, res.Error = StatusSetupError, "commit setup: "+err.Error()
+		res.Verifier.Skipped = "setup commit failed"
+		return res, nil
+	}
+	base, err := gitOutput(ctx, workspace, "rev-parse", "HEAD")
+	base = strings.TrimSpace(base)
+	if err != nil || base == "" {
 		res.Status, res.Error = StatusWorkspaceError, "workspace has no base commit"
 		res.Verifier.Skipped = "workspace base could not be recorded"
 		return res, nil
@@ -662,10 +676,20 @@ func (r *Runner) runCandidate(ctx context.Context, manifest *Manifest, task Task
 	os.WriteFile(filepath.Join(dir, "claude.stdout.json"), stdout.Bytes(), 0o644)
 	os.WriteFile(filepath.Join(dir, "claude.stderr.log"), stderr.Bytes(), 0o644)
 	res.FinalText = finalText(stdout.Bytes())
-	res.Patch = capturePatch(ctx, workspace, base, ignoredInstructions)
+	if rerr := restoreMissingInstructions(ctx, workspace, base, ignoredInstructions); rerr != nil && !res.ModelFailed() {
+		res.Status, res.Error = StatusWorkspaceError, "restore instructions: "+rerr.Error()
+	}
+	patch, perr := capturePatch(ctx, workspace, base)
+	if perr != nil {
+		if !res.ModelFailed() && !res.InfraFailed() {
+			res.Status, res.Error = StatusWorkspaceError, "capture patch: "+perr.Error()
+		}
+	} else {
+		res.Patch = patch
+	}
 	os.WriteFile(filepath.Join(dir, "patch.diff"), []byte(res.Patch), 0o644)
 
-	if res.ModelFailed() {
+	if res.ModelFailed() || res.InfraFailed() {
 		// The verifier would otherwise run against a workspace the model
 		// never finished changing — on an unmodified clone whose tests
 		// already pass, that scores a failed run as a success.
@@ -801,7 +825,7 @@ func (r *Runner) runJudge(ctx context.Context, task Task, attempt int, candidate
 
 func (r *Runner) callJudge(ctx context.Context, sid, prompt string, stdout, stderr io.Writer) (string, error) {
 	body, err := json.Marshal(anthropic.MessagesRequest{
-		Model: r.Options.Judge, MaxTokens: 1024,
+		Model: r.Options.Judge, MaxTokens: judgeMaxTokens,
 		Messages: []anthropic.Message{{Role: "user", Content: anthropic.MessageBody{{Type: "text", Text: prompt}}}},
 	})
 	if err != nil {
@@ -844,6 +868,9 @@ func (r *Runner) callJudge(ctx context.Context, sid, prompt string, stdout, stde
 		if block.Type == "text" {
 			text.WriteString(block.Text)
 		}
+	}
+	if message.StopReason == "max_tokens" {
+		return "", fmt.Errorf("judge response truncated (stop_reason=max_tokens)")
 	}
 	if strings.TrimSpace(text.String()) == "" {
 		return "", errors.New("Messages response contained no text")
@@ -939,8 +966,7 @@ func stripHarnessInstructions(root string) ([]string, error) {
 			}
 			return nil
 		}
-		name := strings.ToLower(entry.Name())
-		if name != "claude.md" && name != "agents.md" {
+		if !isHarnessInstruction(entry.Name()) {
 			return nil
 		}
 		rel, err := filepath.Rel(root, path)
@@ -1025,6 +1051,7 @@ func verify(ctx context.Context, ex Executor, dir string, c Command, logPath str
 }
 
 func evalEnv(env []string, o Options, sid, model string, homes ...string) []string {
+	env = sanitizeEvalEnv(env)
 	if len(homes) > 0 && homes[0] != "" {
 		env = setEnv(env, "HOME", homes[0])
 		env = setEnv(env, "CLAUDE_CONFIG_DIR", filepath.Join(homes[0], ".claude"))
@@ -1072,35 +1099,90 @@ func finalText(data []byte) string {
 	return strings.TrimSpace(string(data))
 }
 
-func capturePatch(ctx context.Context, dir, base string, ignore []string) string {
+func capturePatch(ctx context.Context, dir, base string) (string, error) {
 	// Intent-to-add makes untracked files visible to `git diff` without staging
 	// their contents. Diffing against the immutable pre-agent commit also
 	// includes staged changes and commits the candidate may have created.
 	add := exec.CommandContext(ctx, "git", "-C", dir, "add", "-A", "-N")
-	_ = add.Run()
-	args := []string{"diff", base, "--binary", "--no-ext-diff"}
-	args = append(args, patchIgnoreArgs(ignore)...)
-	return gitOutput(ctx, dir, args...)
+	if out, err := add.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("git add --intent-to-add: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return gitOutput(ctx, dir, "diff", base, "--binary", "--no-ext-diff")
 }
 
-// Isolation removed harness instruction files (CLAUDE.md/AGENTS.md) before
-// the candidate ran. That removal is a harness action, not the candidate's
-// work, and must not appear in the submitted patch.
-func patchIgnoreArgs(ignore []string) []string {
-	if len(ignore) == 0 {
+func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func commitHarnessChanges(ctx context.Context, dir, message string) error {
+	if _, err := gitOutput(ctx, dir, "add", "-A"); err != nil {
+		return err
+	}
+	status, err := gitOutput(ctx, dir, "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(status) == "" {
 		return nil
 	}
-	args := []string{"--", "."}
-	for _, path := range ignore {
-		args = append(args, ":(exclude)"+path)
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "-c", "user.name=gremlord", "-c", "user.email=eval@gremlord", "commit", "--quiet", "--no-gpg-sign", "-m", message)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git commit: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	return args
+	return nil
 }
 
-func gitOutput(ctx context.Context, dir string, args ...string) string {
-	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
-	out, _ := cmd.CombinedOutput()
-	return string(out)
+// Isolation deleted instruction files before the candidate ran. Restore any
+// that are still missing after the turn so the harness deletion is not part of
+// the recorded patch, while candidate recreations remain.
+func restoreMissingInstructions(ctx context.Context, dir, base string, paths []string) error {
+	var tracked []string
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		full := filepath.Join(dir, filepath.FromSlash(path))
+		if _, err := os.Stat(full); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if _, err := gitOutput(ctx, dir, "cat-file", "-e", base+":"+path); err != nil {
+			continue
+		}
+		tracked = append(tracked, path)
+	}
+	if len(tracked) == 0 {
+		return nil
+	}
+	_, err := gitOutput(ctx, dir, append([]string{"checkout", base, "--"}, tracked...)...)
+	return err
+}
+
+func isHarnessInstruction(name string) bool {
+	switch strings.ToLower(name) {
+	case "claude.md", "claude.local.md", "agents.md", "agents.override.md":
+		return true
+	default:
+		return false
+	}
+}
+
+func sanitizeEvalEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, v := range env {
+		key, _, _ := strings.Cut(v, "=")
+		if strings.HasPrefix(key, "CLAUDE_CODE_") {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
 }
 func exitCode(err error) int {
 	if err == nil {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gremlord/gremlord/internal/anthropic"
 	"github.com/gremlord/gremlord/internal/store"
+	"github.com/gremlord/gremlord/internal/wire"
 )
 
 func TestLoadManifestStrictAndValidates(t *testing.T) {
@@ -151,6 +155,31 @@ func TestDeterministicWinnerRequiresVerifier(t *testing.T) {
 	}
 }
 
+func judgeServer(t *testing.T, response string, status int, inspect ...func(*http.Request, []byte)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		for _, fn := range inspect {
+			fn(r, body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status >= 200 && status < 300 {
+			data, _ := json.Marshal(map[string]any{
+				"id": "msg_judge", "type": "message", "role": "assistant", "model": "judge-model",
+				"content":     []map[string]string{{"type": "text", "text": response}},
+				"stop_reason": "end_turn", "usage": map[string]int{"input_tokens": 1, "output_tokens": 1},
+			})
+			_, _ = w.Write(data)
+			return
+		}
+		_, _ = w.Write([]byte(response))
+	}))
+}
+
 type scriptExecutor struct {
 	setupErr     error
 	claudeErr    error
@@ -245,6 +274,108 @@ func TestPrepareWorkspaceChecksOutCommitSHA(t *testing.T) {
 	}
 	if got := headSHA(t, dst); got != sha {
 		t.Errorf("checked out %s, want %s", got, sha)
+	}
+}
+
+func TestCapturePatchIncludesAllCandidateChanges(t *testing.T) {
+	repo := gitRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("staged\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "add", "file.txt").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patch := capturePatch(context.Background(), repo, headSHA(t, repo), nil)
+	for _, want := range []string{"+staged", "diff --git a/untracked.txt b/untracked.txt", "+new"} {
+		if !strings.Contains(patch, want) {
+			t.Errorf("patch missing %q:\n%s", want, patch)
+		}
+	}
+}
+
+func TestCapturePatchIncludesCandidateCommits(t *testing.T) {
+	repo := gitRepo(t)
+	base := headSHA(t, repo)
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("committed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "commit", "-am", "candidate")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v: %s", err, out)
+	}
+	if patch := capturePatch(context.Background(), repo, base, nil); !strings.Contains(patch, "+committed") {
+		t.Fatalf("patch omitted committed change:\n%s", patch)
+	}
+}
+
+func TestCapturePatchExcludesHarnessInstructionRemoval(t *testing.T) {
+	repo := gitRepo(t)
+	base := headSHA(t, repo)
+	instruction := filepath.Join(repo, "CLAUDE.md")
+	if err := os.WriteFile(instruction, []byte("harness instruction\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "CLAUDE.md")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-m", "instructions")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v: %s", err, out)
+	}
+	base = headSHA(t, repo)
+	if err := os.Remove(instruction); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("candidate\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	patch := capturePatch(context.Background(), repo, base, []string{"CLAUDE.md"})
+	if strings.Contains(patch, "CLAUDE.md") || !strings.Contains(patch, "+candidate") {
+		t.Fatalf("patch did not isolate harness removal:\n%s", patch)
+	}
+}
+
+func TestCandidateArgsDisableNonComparableTools(t *testing.T) {
+	args := candidateArgs("claude", "model", "prompt")
+	for _, want := range []string{"Task,WebSearch,WebFetch", "--strict-mcp-config", `{"mcpServers":{}}`, "--setting-sources"} {
+		if !containsArg(args, want) {
+			t.Errorf("candidate args missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestStripHarnessInstructions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "nested", ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "nested", "AGENTS.md"), filepath.Join(root, "nested", ".git", "CLAUDE.md"), filepath.Join(root, "keep.md")} {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := stripHarnessInstructions(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed = %v", removed)
+	}
+	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "nested", "AGENTS.md")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("instruction file survived: %s", path)
+		}
+	}
+	for _, path := range []string{filepath.Join(root, "nested", ".git", "CLAUDE.md"), filepath.Join(root, "keep.md")} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("non-target was removed: %s: %v", path, err)
+		}
 	}
 }
 
@@ -426,24 +557,38 @@ func TestAggregateCountsSingleInfraPairForTwoFailedCandidates(t *testing.T) {
 	}
 }
 
-func TestJudgeRunsFromBlindedWorkspace(t *testing.T) {
+func TestJudgeUsesDirectBlindedMessagesRequest(t *testing.T) {
 	repo := gitRepo(t)
-	ex := &scriptExecutor{
-		claudeStdout: `{"result":"done"}`,
-		judgeStdout:  `{"winner":"tie","confidence":1,"reason":"equal","candidate_1_score":3,"candidate_2_score":3}`,
-	}
+	ex := &scriptExecutor{claudeStdout: `{"result":"done"}`}
+	judge := judgeServer(t, `{"winner":"tie","confidence":1,"reason":"equal","candidate_1_score":3,"candidate_2_score":3}`, http.StatusOK,
+		func(req *http.Request, body []byte) {
+			if req.URL.Path != "/v1/messages" || req.Header.Get("x-api-key") != "token" || req.Header.Get(wire.HeaderPinModel) != "judge-model" {
+				t.Errorf("judge request = %s headers=%v", req.URL.Path, req.Header)
+			}
+			var message anthropic.MessagesRequest
+			if err := json.Unmarshal(body, &message); err != nil {
+				t.Error(err)
+				return
+			}
+			text := message.Messages[0].Content[0].Text
+			if message.Model != "judge-model" || !strings.Contains(text, "Candidate identities and order are randomized") || strings.Contains(text, "Model: a") || strings.Contains(text, "Model: b") {
+				t.Errorf("unblinded or malformed judge request: %+v", message)
+			}
+		})
+	defer judge.Close()
 	out := t.TempDir()
 	runner := &Runner{Exec: ex, Options: Options{
-		Baseline: "a", MUT: "b", Judge: "judge-model", OutputDir: out,
+		Baseline: "a", MUT: "b", Judge: "judge-model", OutputDir: out, BaseURL: judge.URL, Token: "token", Profile: "main",
 		Timeout: time.Minute, ClaudeBin: "claude",
 	}}
 	if _, err := runner.Run(context.Background(), testManifest(repo, "")); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasSuffix(ex.judgeDir, filepath.Join("judge", "workspace")) {
-		t.Fatalf("judge dir = %q, want isolated judge/workspace", ex.judgeDir)
+	if ex.judgeDir != "" {
+		t.Fatalf("judge unexpectedly ran through candidate executor in %q", ex.judgeDir)
 	}
-	entries, err := os.ReadDir(ex.judgeDir)
+	workDir := filepath.Join(out, "tasks", "task-a", "attempt-001", "judge", "workspace")
+	entries, err := os.ReadDir(workDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,9 +599,11 @@ func TestJudgeRunsFromBlindedWorkspace(t *testing.T) {
 
 func TestJudgeFailureIsRecordedAndRunContinues(t *testing.T) {
 	repo := gitRepo(t)
-	ex := &scriptExecutor{claudeStdout: `{"result":"done"}`, judgeStdout: "not json"}
+	ex := &scriptExecutor{claudeStdout: `{"result":"done"}`}
+	judge := judgeServer(t, "not json", http.StatusOK)
+	defer judge.Close()
 	runner := &Runner{Exec: ex, Options: Options{
-		Baseline: "a", MUT: "b", Judge: "judge-model", OutputDir: t.TempDir(),
+		Baseline: "a", MUT: "b", Judge: "judge-model", OutputDir: t.TempDir(), BaseURL: judge.URL,
 		Timeout: time.Minute, ClaudeBin: "claude", Attempts: 2,
 	}}
 	s, err := runner.Run(context.Background(), testManifest(repo, ""))
@@ -502,9 +649,11 @@ func TestTelemetryPopulatesUsageAndRoutes(t *testing.T) {
 }
 
 func TestEvalEnvRoutesAndAttributes(t *testing.T) {
-	env := evalEnv([]string{"ANTHROPIC_API_KEY=bad"}, Options{BaseURL: "http://router", Token: "token", Profile: "main"}, "eval-1", "gpt-5.6-sol")
+	home := filepath.Join(t.TempDir(), "home")
+	env := evalEnv([]string{"ANTHROPIC_API_KEY=bad"}, Options{BaseURL: "http://router", Token: "token", Profile: "main"}, "eval-1", "gpt-5.6-sol", home)
 	joined := strings.Join(env, "\n")
 	for _, want := range []string{
+		"HOME=" + home, "CLAUDE_CONFIG_DIR=" + filepath.Join(home, ".claude"),
 		"ANTHROPIC_BASE_URL=http://router", "ANTHROPIC_AUTH_TOKEN=token",
 		"X-Agentic-Session: eval-1", "AGENTIC_SESSION_ID=eval-1",
 		"X-Agentic-Pin-Model: gpt-5.6-sol",

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -288,7 +288,10 @@ func TestCapturePatchIncludesAllCandidateChanges(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("new\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	patch := capturePatch(context.Background(), repo, headSHA(t, repo), nil)
+	patch, err := capturePatch(context.Background(), repo, headSHA(t, repo))
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, want := range []string{"+staged", "diff --git a/untracked.txt b/untracked.txt", "+new"} {
 		if !strings.Contains(patch, want) {
 			t.Errorf("patch missing %q:\n%s", want, patch)
@@ -307,7 +310,11 @@ func TestCapturePatchIncludesCandidateCommits(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git commit: %v: %s", err, out)
 	}
-	if patch := capturePatch(context.Background(), repo, base, nil); !strings.Contains(patch, "+committed") {
+	patch, err := capturePatch(context.Background(), repo, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(patch, "+committed") {
 		t.Fatalf("patch omitted committed change:\n%s", patch)
 	}
 }
@@ -335,7 +342,13 @@ func TestCapturePatchExcludesHarnessInstructionRemoval(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "file.txt"), []byte("candidate\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	patch := capturePatch(context.Background(), repo, base, []string{"CLAUDE.md"})
+	if err := restoreMissingInstructions(context.Background(), repo, base, []string{"CLAUDE.md"}); err != nil {
+		t.Fatal(err)
+	}
+	patch, err := capturePatch(context.Background(), repo, base)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Contains(patch, "CLAUDE.md") || !strings.Contains(patch, "+candidate") {
 		t.Fatalf("patch did not isolate harness removal:\n%s", patch)
 	}
@@ -355,7 +368,7 @@ func TestStripHarnessInstructions(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "nested", ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "nested", "AGENTS.md"), filepath.Join(root, "nested", ".git", "CLAUDE.md"), filepath.Join(root, "keep.md")} {
+	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "CLAUDE.local.md"), filepath.Join(root, "nested", "AGENTS.md"), filepath.Join(root, "nested", "AGENTS.override.md"), filepath.Join(root, "nested", ".git", "CLAUDE.md"), filepath.Join(root, "keep.md")} {
 		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
 			t.Fatal(err)
 		}
@@ -364,10 +377,10 @@ func TestStripHarnessInstructions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(removed) != 2 {
+	if len(removed) != 4 {
 		t.Fatalf("removed = %v", removed)
 	}
-	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "nested", "AGENTS.md")} {
+	for _, path := range []string{filepath.Join(root, "CLAUDE.md"), filepath.Join(root, "CLAUDE.local.md"), filepath.Join(root, "nested", "AGENTS.md"), filepath.Join(root, "nested", "AGENTS.override.md")} {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
 			t.Errorf("instruction file survived: %s", path)
 		}
@@ -571,7 +584,7 @@ func TestJudgeUsesDirectBlindedMessagesRequest(t *testing.T) {
 				return
 			}
 			text := message.Messages[0].Content[0].Text
-			if message.Model != "judge-model" || !strings.Contains(text, "Candidate identities and order are randomized") || strings.Contains(text, "Model: a") || strings.Contains(text, "Model: b") {
+			if message.Model != "judge-model" || message.MaxTokens != judgeMaxTokens || !strings.Contains(text, "Candidate identities and order are randomized") || strings.Contains(text, "Model: a") || strings.Contains(text, "Model: b") {
 				t.Errorf("unblinded or malformed judge request: %+v", message)
 			}
 		})
@@ -650,7 +663,7 @@ func TestTelemetryPopulatesUsageAndRoutes(t *testing.T) {
 
 func TestEvalEnvRoutesAndAttributes(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
-	env := evalEnv([]string{"ANTHROPIC_API_KEY=bad"}, Options{BaseURL: "http://router", Token: "token", Profile: "main"}, "eval-1", "gpt-5.6-sol", home)
+	env := evalEnv([]string{"ANTHROPIC_API_KEY=bad", "CLAUDE_CODE_DISABLE_THINKING=1", "CLAUDE_CODE_MAX_TURNS=2"}, Options{BaseURL: "http://router", Token: "token", Profile: "main"}, "eval-1", "gpt-5.6-sol", home)
 	joined := strings.Join(env, "\n")
 	for _, want := range []string{
 		"HOME=" + home, "CLAUDE_CONFIG_DIR=" + filepath.Join(home, ".claude"),
@@ -670,6 +683,9 @@ func TestEvalEnvRoutesAndAttributes(t *testing.T) {
 	}
 	if strings.Contains(joined, "ANTHROPIC_API_KEY=") {
 		t.Errorf("api key was not removed")
+	}
+	if strings.Contains(joined, "CLAUDE_CODE_DISABLE_THINKING=") || strings.Contains(joined, "CLAUDE_CODE_MAX_TURNS=") {
+		t.Errorf("claude code controls were inherited: %s", joined)
 	}
 }
 
@@ -743,4 +759,122 @@ func TestEvalEnvPinsToolSearch(t *testing.T) {
 			t.Errorf("with %q inherited, the inherited value survived: %s", inherited, joined)
 		}
 	}
+}
+
+func TestCapturePatchKeepsCandidateInstructionRecreation(t *testing.T) {
+	repo := gitRepo(t)
+	instruction := filepath.Join(repo, "CLAUDE.md")
+	if err := os.WriteFile(instruction, []byte("harness instruction\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "-C", repo, "add", "CLAUDE.md")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	cmd = exec.Command("git", "-C", repo, "commit", "-m", "instructions")
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v: %s", err, out)
+	}
+	base := headSHA(t, repo)
+	if err := os.Remove(instruction); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(instruction, []byte("candidate instruction\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := restoreMissingInstructions(context.Background(), repo, base, []string{"CLAUDE.md"}); err != nil {
+		t.Fatal(err)
+	}
+	patch, err := capturePatch(context.Background(), repo, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(patch, "diff --git a/CLAUDE.md b/CLAUDE.md") || !strings.Contains(patch, "+candidate instruction") {
+		t.Fatalf("candidate instruction recreation was dropped:\n%s", patch)
+	}
+}
+
+func TestCapturePatchReportsGitFailure(t *testing.T) {
+	if _, err := capturePatch(context.Background(), t.TempDir(), "HEAD"); err == nil {
+		t.Fatal("expected capture error for a non-git directory")
+	}
+}
+
+func TestResumeRejectsJudgeMismatch(t *testing.T) {
+	repo := gitRepo(t)
+	out := t.TempDir()
+	old := &Summary{SchemaVersion: SchemaVersion, Name: "unit", Baseline: "a", MUT: "b", Judge: "sonnet", Seed: 1}
+	if err := writeJSONAtomic(filepath.Join(out, "summary.json"), old); err != nil {
+		t.Fatal(err)
+	}
+	runner := &Runner{Exec: &scriptExecutor{claudeStdout: `{"result":"done"}`}, Options: Options{
+		Baseline: "a", MUT: "b", Judge: "opus", Resume: true, OutputDir: out,
+		Timeout: time.Minute, ClaudeBin: "claude",
+	}}
+	if _, err := runner.Run(context.Background(), testManifest(repo, "")); err == nil || !strings.Contains(err.Error(), "do not match") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestJudgeRejectsTruncatedResponse(t *testing.T) {
+	repo := gitRepo(t)
+	ex := &scriptExecutor{claudeStdout: `{"result":"done"}`}
+	judge := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		data, _ := json.Marshal(map[string]any{
+			"id": "msg_judge", "type": "message", "role": "assistant", "model": "judge-model",
+			"content":     []map[string]string{{"type": "text", "text": `{"winner":"tie"`}},
+			"stop_reason": "max_tokens",
+		})
+		_, _ = w.Write(data)
+	}))
+	defer judge.Close()
+	runner := &Runner{Exec: ex, Options: Options{
+		Baseline: "a", MUT: "b", Judge: "judge-model", OutputDir: t.TempDir(), BaseURL: judge.URL,
+		Timeout: time.Minute, ClaudeBin: "claude",
+	}}
+	s, err := runner.Run(context.Background(), testManifest(repo, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.JudgeErrors != 1 || s.Pairs[0].Winner != WinnerJudgeError || !strings.Contains(s.Pairs[0].JudgeError, "truncated") {
+		t.Fatalf("summary = %+v", s)
+	}
+}
+
+func TestSetupChangesAreCommittedOutOfTheCandidatePatch(t *testing.T) {
+	repo := gitRepo(t)
+	ex := &setupMutatingExecutor{scriptExecutor: scriptExecutor{claudeStdout: `{"result":"done"}`}}
+	manifest := testManifest(repo, "")
+	manifest.Setup = Command{Run: []string{"setup"}}
+	out := t.TempDir()
+	runner := &Runner{Exec: ex, Options: Options{
+		Baseline: "a", MUT: "b", Judge: "none", OutputDir: out,
+		Timeout: time.Minute, ClaudeBin: "claude",
+	}}
+	if _, err := runner.Run(context.Background(), manifest); err != nil {
+		t.Fatal(err)
+	}
+	patch, err := os.ReadFile(filepath.Join(out, "tasks", "task-a", "attempt-001", "baseline", "patch.diff"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(patch), "+setup") {
+		t.Fatalf("setup edit leaked into candidate patch:\n%s", patch)
+	}
+}
+
+type setupMutatingExecutor struct {
+	scriptExecutor
+}
+
+func (s *setupMutatingExecutor) Run(ctx context.Context, dir string, env []string, argv []string, input io.Reader, stdout, stderr io.Writer) error {
+	if containsArg(argv, "setup") {
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("setup\n"), 0o644); err != nil {
+			return err
+		}
+		return nil
+	}
+	return s.scriptExecutor.Run(ctx, dir, env, argv, input, stdout, stderr)
 }


### PR DESCRIPTION
## Summary

- isolate each evaluation candidate from user configuration, MCP servers, repository instructions, subagents, and web tools
- capture complete candidate submissions relative to the recorded pre-agent commit, including untracked, staged, and committed changes
- report agent-turn time separately from Docker provisioning and run blinded judging through the router's Messages API
- document the broader Codex-vs-Claude-Code harness evaluation plan

## Testing

- `env -u GREMLORD_SESSION_ID -u AGENTIC_SESSION_ID go test ./...`
- `go vet ./...`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)