### PR TITLE
installer: resolve latest release via redirect, not the API

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,9 +55,13 @@ prompt_install() {
 }
 
 echo "Fetching latest release..."
-tag=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-  | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
-if [ -z "$tag" ]; then
+# Resolve GitHub's stable latest-release redirect instead of spending an
+# unauthenticated API request. The API limit is shared by every user behind a
+# NAT/proxy and returns 403 once exhausted, which made the installer flaky.
+latest_url=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+  "https://github.com/$REPO/releases/latest")
+tag=${latest_url##*/}
+if [ -z "$tag" ] || [ "$tag" = "latest" ]; then
   echo "could not determine latest release of $REPO" >&2
   exit 1
 fi


### PR DESCRIPTION
## Problem

Users hit:
```
Fetching latest release...
curl: (56) The requested URL returned error: 403
could not determine latest release of gremlord/gremlord
```

`install.sh` fetched the latest release via `api.github.com/repos/$REPO/releases/latest`, an unauthenticated GitHub API call capped at 60 requests/hour **per IP**. Anyone behind a shared NAT, VPN, or corporate proxy that exhausts that shared quota gets a bare 403 with no way to retry around it.

## Fix

Resolve `https://github.com/$REPO/releases/latest`'s redirect instead of calling the API — this endpoint isn't subject to the API rate limit, and the tag is the last path segment of the redirect target (`.../releases/tag/v0.1.3-gremlord`).

## Verification

- `sh -n install.sh` — syntax OK
- Resolved tag `v0.1.3-gremlord` and downloaded the real release asset
- Full end-to-end run with `GREMLORD_INSTALL_DIR` pointed at a scratch dir produced a working, executable `gremlord` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)