### PR TITLE
Accept the local router token from either credential header

### DIFF
--- a/internal/router/auth_test.go
+++ b/internal/router/auth_test.go
@@ -1,0 +1,62 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// authProbe posts to the reload endpoint, which sits behind auth but does not
+// touch an upstream, with whichever credential headers the case supplies.
+func authProbe(t *testing.T, ts *httptest.Server, apiKey, bearer string) int {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/messages/count_tokens", strings.NewReader(`{}`))
+	req.Header.Set("content-type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("x-api-key", apiKey)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestAuthAcceptsLocalTokenFromEitherHeader covers the shape Claude Code sends
+// when a /login managed key and ANTHROPIC_AUTH_TOKEN are both present: the
+// managed key rides in x-api-key and the local token in Authorization. The
+// router must recognise its own token wherever it appears, and still refuse
+// requests that carry it in neither header.
+func TestAuthAcceptsLocalTokenFromEitherHeader(t *testing.T) {
+	ts, _ := newTestServer(t, "http://127.0.0.1:0", nil)
+
+	cases := []struct {
+		name     string
+		apiKey   string
+		bearer   string
+		wantAuth bool
+	}{
+		{"x-api-key only", testToken, "", true},
+		{"bearer only", "", testToken, true},
+		{"managed key in x-api-key, local token in bearer", "sk-ant-managed-key", testToken, true},
+		{"local token in x-api-key, foreign bearer", testToken, "some-oauth-token", true},
+		{"foreign key in both", "sk-ant-managed-key", "some-oauth-token", false},
+		{"no credentials", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := authProbe(t, ts, tc.apiKey, tc.bearer)
+			if tc.wantAuth && got == http.StatusUnauthorized {
+				t.Fatalf("expected the local token to be accepted, got 401")
+			}
+			if !tc.wantAuth && got != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", got)
+			}
+		})
+	}
+}

--- a/internal/router/server.go
+++ b/internal/router/server.go
@@ -103,11 +103,15 @@ func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		got := r.Header.Get("x-api-key")
-		if got == "" {
-			got = strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-		}
-		if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+		// Claude Code sends BOTH headers when a /login managed key and
+		// ANTHROPIC_AUTH_TOKEN are present: x-api-key carries the managed key
+		// and Authorization carries our local token. Accept the local token
+		// from either header rather than trusting only the first one found.
+		apiKey := r.Header.Get("x-api-key")
+		bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		apiKeyOK := apiKey != "" && subtle.ConstantTimeCompare([]byte(apiKey), []byte(s.token)) == 1
+		bearerOK := bearer != "" && subtle.ConstantTimeCompare([]byte(bearer), []byte(s.token)) == 1
+		if !apiKeyOK && !bearerOK {
 			anthropic.WriteError(w, 401, "authentication_error",
 				"gremlord router: invalid local token (launch sessions via `gremlord`)")
 			return


### PR DESCRIPTION
## Summary

The router rejects every request from a Claude Code session that is logged in with an organization-managed key, so `gremlord -p <profile>` loops on `401 gremlord router: invalid local token` and never reaches an upstream. This change makes `auth()` accept the local token from either the `x-api-key` or the `Authorization` header.

## Why

Claude Code (2.1.266) warns `Both ANTHROPIC_AUTH_TOKEN and /login managed key set` and then sends both credentials on every request: the managed key in `x-api-key` and gremlord's token in `Authorization: Bearer`. `auth()` reads `x-api-key` first and only falls back to `Authorization` when `x-api-key` is empty, so the managed key is compared against the local token and the request fails. `router.log` shows only `became router leader` lines with no requests, because the rejection happens before logging.

## What changed

- `internal/router/server.go`: compare both headers against the local token and accept if either matches. Both comparisons remain constant-time against the same secret, so nothing gets weaker; a request that carries the token in neither header is still refused.
- `internal/router/auth_test.go`: new table test covering x-api-key only, bearer only, managed key plus local bearer (the failing case), local key plus foreign bearer, foreign credentials in both headers, and no credentials.

## How it was verified

- `go test ./internal/router/` passes, including the new test.
- Built and ran locally on macOS arm64 with Claude Code 2.1.266 logged in via `/login` with an organization account: `gremlord -p grok` now starts a session that routes to xAI, where the release binary looped on 401.

## Risk and rollout

Auth-path change only. No config, wire, or CLI surface changes. Users without a managed key see no difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
