### PR TITLE
Default the launch splash to 3 seconds, not 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ gremlord budget set --daily 25
 
 Edits apply to live sessions immediately — the CLI hot-reloads the running router.
 
-Launching `gremlord` holds the Gremlord banner for ten seconds before Claude Code
+Launching `gremlord` holds the Gremlord banner for three seconds before Claude Code
 takes over. `splash_seconds: 0` in the config turns it off permanently, or
 `GREMLORD_SPLASH_SECONDS=0` for one shell. It writes to stderr and is skipped
 entirely when stderr is not a terminal, so pipes, CI and scripted launches never

--- a/internal/launch/splash.go
+++ b/internal/launch/splash.go
@@ -18,7 +18,7 @@ var bannerFS embed.FS
 
 // DefaultSplashSeconds is how long the banner is held before Claude Code takes
 // the terminal.
-const DefaultSplashSeconds = 10
+const DefaultSplashSeconds = 3
 
 var taglines = []string{
 	"it's smart. it's in the wires. it's already in prod.",


### PR DESCRIPTION
## Summary
Ten seconds holding the banner before Claude Code takes the terminal was too much. Default is now 3 seconds.

`splash_seconds` in config and `GREMLORD_SPLASH_SECONDS` still override it, including disabling with `0`.

## Verification
- `go build ./...`, `go vet ./...`
- `go test ./internal/launch/...` (existing test asserts against the `DefaultSplashSeconds` constant symbolically, so it covers the new value automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)