### PR TITLE
openaibe: strip Unicode-property regex patterns from tool schemas

### DIFF
--- a/internal/backend/openaibe/request.go
+++ b/internal/backend/openaibe/request.go
@@ -51,7 +51,7 @@ func TranslateRequest(req *anthropic.MessagesRequest, route config.Resolved) (*o
 		}
 		out.Tools = append(out.Tools, openai.Tool{
 			Type:     "function",
-			Function: openai.Function{Name: t.Name, Description: t.Description, Parameters: t.InputSchema},
+			Function: openai.Function{Name: t.Name, Description: t.Description, Parameters: sanitizeToolSchema(t.InputSchema)},
 		})
 	}
 

--- a/internal/backend/openaibe/responses_request.go
+++ b/internal/backend/openaibe/responses_request.go
@@ -45,7 +45,7 @@ func TranslateResponsesRequest(req *anthropic.MessagesRequest, route config.Reso
 			Type:        "function",
 			Name:        t.Name,
 			Description: t.Description,
-			Parameters:  t.InputSchema,
+			Parameters:  sanitizeToolSchema(t.InputSchema),
 		})
 	}
 

--- a/internal/backend/openaibe/schema.go
+++ b/internal/backend/openaibe/schema.go
@@ -1,0 +1,78 @@
+package openaibe
+
+import (
+	"encoding/json"
+)
+
+// sanitizeToolSchema strips JSON Schema "pattern" constraints that use
+// Unicode property escapes (\p{...}, \P{...}). Claude Code's own built-in
+// tools (Artifact among them) emit such patterns, which Go's regexp package
+// compiles fine but OpenAI's function-calling schema validator rejects
+// outright with "is not a 'regex'" — turning every request that offers the
+// tool into a hard 400, not a degraded one. Dropping the unsupported
+// constraint costs input validation Claude Code never relied on gremlord to
+// enforce anyway; keeping the tool callable is worth more than keeping the
+// pattern.
+//
+// On any unmarshal/marshal failure the original schema is returned
+// unchanged — a schema this can't safely rewrite is better sent as-is than
+// silently dropped.
+func sanitizeToolSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	changed := stripUnsupportedPatterns(v)
+	if !changed {
+		return raw
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// stripUnsupportedPatterns walks a decoded JSON Schema (as produced by
+// encoding/json into map[string]any / []any) and deletes any "pattern" key
+// whose value uses a Unicode property escape. It recurses into every map
+// value and slice element — not just known schema keywords — since a
+// pattern can appear nested under properties, items, additionalProperties,
+// anyOf/oneOf/allOf, $defs/definitions, or a provider-specific extension.
+func stripUnsupportedPatterns(v any) bool {
+	changed := false
+	switch node := v.(type) {
+	case map[string]any:
+		if p, ok := node["pattern"].(string); ok && hasUnicodePropertyEscape(p) {
+			delete(node, "pattern")
+			changed = true
+		}
+		for _, child := range node {
+			if stripUnsupportedPatterns(child) {
+				changed = true
+			}
+		}
+	case []any:
+		for _, child := range node {
+			if stripUnsupportedPatterns(child) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// hasUnicodePropertyEscape reports whether a regex pattern contains a
+// \p{...} or \P{...} Unicode property/script escape — supported by Go's
+// RE2-derived regexp package but rejected by OpenAI's schema validator.
+func hasUnicodePropertyEscape(pattern string) bool {
+	for i := 0; i+2 < len(pattern); i++ {
+		if pattern[i] == '\\' && (pattern[i+1] == 'p' || pattern[i+1] == 'P') && pattern[i+2] == '{' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/backend/openaibe/schema_test.go
+++ b/internal/backend/openaibe/schema_test.go
@@ -1,0 +1,74 @@
+package openaibe
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeToolSchemaStripsUnicodePropertyPattern(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"title": {
+				"type": "string",
+				"pattern": "^(?!__.*__$)[^\\p{Cc}\\p{Cf}\\p{Zl}\\p{Zp}\"\\\\./[\\]]{1,200}$"
+			},
+			"nested": {
+				"anyOf": [
+					{"type": "string", "pattern": "\\p{L}+"},
+					{"type": "integer"}
+				]
+			}
+		}
+	}`)
+	out := sanitizeToolSchema(raw)
+	if strings.Contains(string(out), "pattern") {
+		t.Fatalf("pattern survived sanitization: %s", out)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(out, &v); err != nil {
+		t.Fatalf("sanitized schema is not valid JSON: %v", err)
+	}
+	props, ok := v["properties"].(map[string]any)
+	if !ok || props["title"] == nil {
+		t.Fatalf("sanitization dropped unrelated schema content: %s", out)
+	}
+}
+
+func TestSanitizeToolSchemaLeavesOrdinaryPatternsAlone(t *testing.T) {
+	raw := json.RawMessage(`{"type":"string","pattern":"^[a-z0-9_-]{1,64}$"}`)
+	out := sanitizeToolSchema(raw)
+	if string(out) != string(raw) {
+		t.Fatalf("ordinary pattern was rewritten: got %s want %s", out, raw)
+	}
+}
+
+func TestSanitizeToolSchemaPassesThroughInvalidJSON(t *testing.T) {
+	raw := json.RawMessage(`not json`)
+	out := sanitizeToolSchema(raw)
+	if string(out) != string(raw) {
+		t.Fatalf("invalid JSON was mutated: got %s want %s", out, raw)
+	}
+}
+
+func TestSanitizeToolSchemaEmpty(t *testing.T) {
+	if out := sanitizeToolSchema(nil); out != nil {
+		t.Fatalf("nil schema should stay nil, got %s", out)
+	}
+}
+
+func TestHasUnicodePropertyEscape(t *testing.T) {
+	cases := map[string]bool{
+		`^[a-z]+$`:            false,
+		`\p{L}+`:              true,
+		`\P{Cc}`:              true,
+		`literal \p no brace`: false,
+		``:                    false,
+	}
+	for pattern, want := range cases {
+		if got := hasUnicodePropertyEscape(pattern); got != want {
+			t.Errorf("hasUnicodePropertyEscape(%q) = %v, want %v", pattern, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Claude Code sessions routed through an OpenAI-compatible backend 400 on any request that offers the `Artifact` tool:

```
API Error: 400 openai: Invalid schema for function 'Artifact':
'^(?!__.*__$)[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}"\\./[\]]{1,200}$' is not a 'regex'.
```

Claude Code's built-in tools emit JSON Schema `pattern` constraints using `\p{...}`/`\P{...}` Unicode property escapes. Go's regexp package compiles those; OpenAI's function-calling schema validator does not. Because `openaibe` forwarded `input_schema` unchanged, every request that offered such a tool failed before reaching the model.

## Fix

Walk translated tool schemas recursively and drop only `pattern` keys whose value uses a Unicode property escape. Applied on both Chat Completions and Responses translation paths. Ordinary ASCII patterns, unrelated schema content, and unparseable JSON are left alone.

## Verification

- `go test ./internal/backend/openaibe/...`
- `go vet ./...`, `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)